### PR TITLE
Refactoring: OwnCloudNote -> CloudNote

### DIFF
--- a/app/src/androidTest/java/it/niedermann/owncloud/notes/model/NoteTest.java
+++ b/app/src/androidTest/java/it/niedermann/owncloud/notes/model/NoteTest.java
@@ -11,7 +11,7 @@ import java.util.Calendar;
 public class NoteTest extends TestCase {
 
     public void testMarkDownStrip() {
-        OwnCloudNote note = new OwnCloudNote(0, Calendar.getInstance(), "#Title", "", false);
+        CloudNote note = new CloudNote(0, Calendar.getInstance(), "#Title", "", false);
         assertTrue("Title".equals(note.getTitle()));
         note.setTitle("* Aufzählung");
         assertTrue("Aufzählung".equals(note.getTitle()));

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/CloudNote.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/CloudNote.java
@@ -9,17 +9,17 @@ import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
 import it.niedermann.owncloud.notes.util.NoteUtil;
 
 /**
- * OwnCloudNote represents a remote note from an OwnCloud server.
+ * CloudNote represents a remote note from an OwnCloud server.
  * It can be directly generated from the JSON answer from the server.
  */
-public class OwnCloudNote implements Serializable {
+public class CloudNote implements Serializable {
     private long remoteId = 0;
     private String title = "";
     private Calendar modified = null;
     private String content = "";
     private boolean favorite = false;
 
-    public OwnCloudNote(long remoteId, Calendar modified, String title, String content, boolean favorite) {
+    public CloudNote(long remoteId, Calendar modified, String title, String content, boolean favorite) {
         this.remoteId = remoteId;
         if (title != null)
             setTitle(title);

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/DBNote.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/DBNote.java
@@ -8,9 +8,9 @@ import it.niedermann.owncloud.notes.util.NoteUtil;
 
 /**
  * DBNote represents a single note from the local SQLite database with all attributes.
- * It extends OwnCloudNote with attributes required for local data management.
+ * It extends CloudNote with attributes required for local data management.
  */
-public class DBNote extends OwnCloudNote implements Item, Serializable {
+public class DBNote extends CloudNote implements Item, Serializable {
 
     private long id;
     private DBStatus status;

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 
 import it.niedermann.owncloud.notes.model.DBNote;
 import it.niedermann.owncloud.notes.model.DBStatus;
-import it.niedermann.owncloud.notes.model.OwnCloudNote;
+import it.niedermann.owncloud.notes.model.CloudNote;
 import it.niedermann.owncloud.notes.util.ICallback;
 import it.niedermann.owncloud.notes.util.NoteUtil;
 
@@ -102,7 +102,7 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      */
     @SuppressWarnings("UnusedReturnValue")
     public long addNoteAndSync(String content) {
-        OwnCloudNote note = new OwnCloudNote(0, Calendar.getInstance(), NoteUtil.generateNoteTitle(content), content, false);
+        CloudNote note = new CloudNote(0, Calendar.getInstance(), NoteUtil.generateNoteTitle(content), content, false);
         return addNoteAndSync(note);
     }
 
@@ -112,7 +112,7 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      * @param note Note
      */
     @SuppressWarnings("UnusedReturnValue")
-    public long addNoteAndSync(OwnCloudNote note) {
+    public long addNoteAndSync(CloudNote note) {
         DBNote dbNote =  new DBNote(0, 0, note.getModified(), note.getTitle(), note.getContent(), note.isFavorite(), DBStatus.LOCAL_EDITED);
         long id = addNote(dbNote);
         getNoteServerSyncHelper().scheduleSync(true);
@@ -123,9 +123,9 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      * Inserts a note directly into the Database.
      * No Synchronisation will be triggered! Use addNoteAndSync()!
      *
-     * @param note Note to be added. Remotely created Notes must be of type OwnCloudNote and locally created Notes must be of Type DBNote (with DBStatus.LOCAL_EDITED)!
+     * @param note Note to be added. Remotely created Notes must be of type CloudNote and locally created Notes must be of Type DBNote (with DBStatus.LOCAL_EDITED)!
      */
-    long addNote(OwnCloudNote note) {
+    long addNote(CloudNote note) {
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues values = new ContentValues();
         if(note instanceof DBNote) {
@@ -323,7 +323,7 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      *
      * @return The number of the Rows affected.
      */
-    int updateNote(long id, OwnCloudNote remoteNote, DBNote forceUnchangedDBNoteState) {
+    int updateNote(long id, CloudNote remoteNote, DBNote forceUnchangedDBNoteState) {
         SQLiteDatabase db = this.getWritableDatabase();
 
         // First, update the remote ID, since this field cannot be changed in parallel, but have to be updated always.

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
@@ -25,9 +25,9 @@ import java.util.Set;
 
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.android.activity.SettingsActivity;
+import it.niedermann.owncloud.notes.model.CloudNote;
 import it.niedermann.owncloud.notes.model.DBNote;
 import it.niedermann.owncloud.notes.model.DBStatus;
-import it.niedermann.owncloud.notes.model.OwnCloudNote;
 import it.niedermann.owncloud.notes.util.ICallback;
 import it.niedermann.owncloud.notes.util.NotesClient;
 import it.niedermann.owncloud.notes.util.NotesClientUtil.LoginStatus;
@@ -215,7 +215,7 @@ public class NoteServerSyncHelper {
             for (DBNote note : notes) {
                 Log.d(getClass().getSimpleName(), "   Process Local Note: "+note);
                 try {
-                    OwnCloudNote remoteNote=null;
+                    CloudNote remoteNote=null;
                     switch(note.getStatus()) {
                         case LOCAL_EDITED:
                             Log.d(getClass().getSimpleName(), "   ...create/edit");
@@ -272,10 +272,10 @@ public class NoteServerSyncHelper {
                 for (DBNote note : localNotes) {
                     localIDmap.put(note.getRemoteId(), note.getId());
                 }
-                List<OwnCloudNote> remoteNotes = client.getNotes();
+                List<CloudNote> remoteNotes = client.getNotes();
                 Set<Long> remoteIDs = new HashSet<>();
                 // pull remote changes: update or create each remote note
-                for (OwnCloudNote remoteNote : remoteNotes) {
+                for (CloudNote remoteNote : remoteNotes) {
                     Log.d(getClass().getSimpleName(), "   Process Remote Note: "+remoteNote);
                     remoteIDs.add(remoteNote.getRemoteId());
                     if(localIDmap.containsKey(remoteNote.getRemoteId())) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/NotesClient.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/NotesClient.java
@@ -19,7 +19,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import it.niedermann.owncloud.notes.model.OwnCloudNote;
+import it.niedermann.owncloud.notes.model.CloudNote;
 
 public class NotesClient {
 
@@ -43,7 +43,7 @@ public class NotesClient {
         this.password = password;
     }
 
-    private OwnCloudNote getNoteFromJSON(JSONObject json) throws JSONException {
+    private CloudNote getNoteFromJSON(JSONObject json) throws JSONException {
         long noteId = 0;
         String noteTitle = "";
         String noteContent = "";
@@ -65,11 +65,11 @@ public class NotesClient {
         if (!json.isNull(key_favorite)) {
             noteFavorite = json.getBoolean(key_favorite);
         }
-        return new OwnCloudNote(noteId, noteModified, noteTitle, noteContent, noteFavorite);
+        return new CloudNote(noteId, noteModified, noteTitle, noteContent, noteFavorite);
     }
 
-    public List<OwnCloudNote> getNotes() throws JSONException, IOException {
-        List<OwnCloudNote> notesList = new ArrayList<>();
+    public List<CloudNote> getNotes() throws JSONException, IOException {
+        List<CloudNote> notesList = new ArrayList<>();
         JSONArray notes = new JSONArray(requestServer("notes", METHOD_GET, null));
         for (int i = 0; i < notes.length(); i++) {
             JSONObject json = notes.getJSONObject(i);
@@ -87,12 +87,12 @@ public class NotesClient {
      * @throws IOException
      */
     @SuppressWarnings("unused")
-    public OwnCloudNote getNoteById(long id) throws JSONException, IOException {
+    public CloudNote getNoteById(long id) throws JSONException, IOException {
         JSONObject json = new JSONObject(requestServer("notes/" + id, METHOD_GET, null));
         return getNoteFromJSON(json);
     }
 
-    private OwnCloudNote putNote(OwnCloudNote note, String path, String method)  throws JSONException, IOException {
+    private CloudNote putNote(CloudNote note, String path, String method)  throws JSONException, IOException {
         JSONObject paramObject = new JSONObject();
         paramObject.accumulate(key_content, note.getContent());
         paramObject.accumulate(key_modified, note.getModified().getTimeInMillis()/1000);
@@ -104,16 +104,16 @@ public class NotesClient {
     /**
      * Creates a Note on the Server
      *
-     * @param note {@link OwnCloudNote} - the new Note
+     * @param note {@link CloudNote} - the new Note
      * @return Created Note including generated Title, ID and lastModified-Date
      * @throws JSONException
      * @throws IOException
      */
-    public OwnCloudNote createNote(OwnCloudNote note) throws JSONException, IOException {
+    public CloudNote createNote(CloudNote note) throws JSONException, IOException {
         return putNote(note, "notes", METHOD_POST);
     }
 
-    public OwnCloudNote editNote(OwnCloudNote note) throws JSONException, IOException {
+    public CloudNote editNote(CloudNote note) throws JSONException, IOException {
         return putNote(note, "notes/" + note.getRemoteId(), METHOD_PUT);
     }
 


### PR DESCRIPTION
see #147

This only changes the name of the class `OwnCloudNote`. The package is still `it.niedermann.owncloud.notes`, since changing this will have more impacts.