### PR TITLE
trim leading and trailing spaces in the URL

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
@@ -86,7 +86,7 @@ public class SettingsActivity extends AppCompatActivity {
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                String url = field_url.getText().toString();
+                String url = field_url.getText().toString().trim();
 
                 if (!url.endsWith("/")) {
                     url += "/";
@@ -159,7 +159,7 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     private void login() {
-        String url = field_url.getText().toString();
+        String url = field_url.getText().toString().trim();
         String username = field_username.getText().toString();
         String password = field_password.getText().toString();
 


### PR DESCRIPTION
I added trim() to the URL handling since user typos like a space can be seen (in the text field) but will block the server check. So this change is just for UX reasons. 😸 

**Android version:** Android 7.1.1

**Device**: Nexus5X

**System language**: language English, Location Germany (to have English language and the Euro)

**App version:** git master 23/01/2017

**App source:** git master

**Steps to reproduce:**
  1. open the app
  2. try a login and add a trailing space to the URL