### PR TITLE
Fix string-resources / Adjust lint-options to make a standard gradle-build possible

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        disable 'MissingTranslation'
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Servidor</string>
     <string name="settings_url">Adreça del servidor</string>
     <string name="settings_url_check_description">Mostra si es pot fer ping a l\\\'adreça</string>
-    <string name="settings_url_warn_http">ATENCIÓ: \"http\" és insegur. Si us plau utilitzeu \"https\".</string>
+    <string name="settings_url_warn_http">ATENCIÓ: "http" és insegur. Si us plau utilitzeu "https".</string>
     <string name="settings_username">Nom d\\\'usuari</string>
     <string name="settings_password">Contrasenya</string>
     <string name="settings_password_check_description">Mostar si les credencials son correctes</string>
@@ -74,13 +74,13 @@
     <string name="about_translators">pejakm (Serbi), ageru (Francès (França)), proninyaroslav (Rus), mist (txec)</string>
     <string name="about_testers_title">Provadors</string>
     <string name="about_source_title">Codi font</string>
-    <string name="about_source">Aquest projecte es troba a GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Aquest projecte es troba a GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Problemes</string>
     <string name="about_app_license_title">Llicència de l\\\'aplicació</string>
     <string name="about_app_license">Aquesta aplicació està llicenciada sota GNU GENERAL PUBLIC LICENSE v3+</string>
     <string name="about_app_license_button">Veure llicència</string>
     <string name="about_app_icon_disclaimer_title">Icona de l\\\'aplicació</string>
-    <string name="about_app_icon_disclaimer"><p>Icona original feta per <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> des de <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Icona original feta per <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> des de <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Icones</string>
     <string name="about_credits_tab_title">Crèdits</string>
     <string name="about_contribution_tab_title">Contribució</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Server</string>
     <string name="settings_url">Adresa serveru</string>
     <string name="settings_url_check_description">Ukáže, zda adresa odpovídá na ping.</string>
-    <string name="settings_url_warn_http">POZOR: \"http\" není bezpečné. Prosím použijte \"https\"</string>
+    <string name="settings_url_warn_http">POZOR: "http" není bezpečné. Prosím použijte "https"</string>
     <string name="settings_username">Uživatelské jméno</string>
     <string name="settings_password">Heslo</string>
     <string name="settings_password_check_description">Ukáže, zda jsou přihlašovací údaje správné.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testeři</string>
     <string name="about_source_title">Zdrojový kód</string>
-    <string name="about_source">Tento projekt je hostován na GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Tento projekt je hostován na GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Problémy</string>
-    <string name="about_issues">Chyby, nápady na vylepšení a nové funkce můžete nahlásit na GitHub issue tracker: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Chyby, nápady na vylepšení a nové funkce můžete nahlásit na GitHub issue tracker: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Licence aplikace</string>
     <string name="about_app_license">Tato aplikace je licencována pod GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Zobrazit licenci</string>
     <string name="about_app_icon_disclaimer_title">Ikona aplikace</string>
-    <string name="about_app_icon_disclaimer"><p>Originální ikonu vytvořil <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> z <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Originální ikonu vytvořil <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> z <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikony</string>
-    <string name="about_icons_disclaimer"><p>Všechny další ikony, které tato aplikace využívá jsou <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Icons</a> vytvořeno Google Inc. a licencováno pod Creative Commons License.</p></string>
+    <string name="about_icons_disclaimer"><p>Všechny další ikony, které tato aplikace využívá jsou <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> vytvořeno Google Inc. a licencováno pod Creative Commons License.</p></string>
 
     <string name="about_credits_tab_title">Zásluhy</string>
     <string name="about_contribution_tab_title">Příspěvek</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Διακομιστής</string>
     <string name="settings_url">Διεύθυνση διακομιστή</string>
     <string name="settings_url_check_description">Εμφανίζει εάν μπορεί να γίνει ping στην διεύθυνση.</string>
-    <string name="settings_url_warn_http">ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Το \"http\" δεν είναι ασφαλές. Παρακαλούμε χρησιμοποιήστε το \"https\".</string>
+    <string name="settings_url_warn_http">ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Το "http" δεν είναι ασφαλές. Παρακαλούμε χρησιμοποιήστε το "https".</string>
     <string name="settings_username">Όνομα χρήστη</string>
     <string name="settings_password">Συνθηματικό</string>
     <string name="settings_password_check_description">Εμφανίζει εάν τα διαπιστευτήρια είναι σωστά.</string>
@@ -79,9 +79,9 @@
     <string name="about_app_license">Αυτή η εφαρμογή υπόκεινται στην άδεια χρήσης GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Προβολή άδειας χρήσης</string>
     <string name="about_app_icon_disclaimer_title">Εικονίδιο εφαρμογής</string>
-    <string name="about_app_icon_disclaimer"><p>Το αυθεντικό εικονίδιο κατασκευάστηκε από τον <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> από το <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Το αυθεντικό εικονίδιο κατασκευάστηκε από τον <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> από το <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Εικονίδια</string>
-    <string name="about_icons_disclaimer"><p>Όλα τα υπόλοιπα εικονίδια που χρησιμοποιούνται από αυτή την εφαρμογή είναι <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Εικονίδια Υλικού Σχεδίασης</a> κατασκευασμένα από την Google Inc. και έχουν άδεια χρήσης: Creative Commons License.</p></string>
+    <string name="about_icons_disclaimer"><p>Όλα τα υπόλοιπα εικονίδια που χρησιμοποιούνται από αυτή την εφαρμογή είναι <a href="https://materialdesignicons.com/" title="Link to Website">Εικονίδια Υλικού Σχεδίασης</a> κατασκευασμένα από την Google Inc. και έχουν άδεια χρήσης: Creative Commons License.</p></string>
 
     <string name="about_credits_tab_title">Μνεία</string>
     <string name="about_contribution_tab_title">Συνεισφορά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Servidor</string>
     <string name="settings_url">Dirección de Servidor</string>
     <string name="settings_url_check_description">Muestra si la dirección puede ser encontrada.</string>
-    <string name="settings_url_warn_http">AVISO: \"http\" es inseguro. Por favor, use \"https\".</string>
+    <string name="settings_url_warn_http">AVISO: "http" es inseguro. Por favor, use "https".</string>
     <string name="settings_username">Nombre de usuario</string>
     <string name="settings_password">Contraseña</string>
     <string name="settings_password_check_description">Aparece si las credenciales son correctas.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (serbio), ageru (Francés [Francia]), proninyaroslav (ruso), mist (checo)</string>
     <string name="about_testers_title">Testers</string>
     <string name="about_source_title">Código fuente</string>
-    <string name="about_source">Este proyecto se aloja en GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/nextcloud-notes/</a></string>
+    <string name="about_source">Este proyecto se aloja en GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/nextcloud-notes/</a></string>
     <string name="about_issues_title">Problemas</string>
-    <string name="about_issues">Puedes informar de errores, proponer mejoras y pedir características en el tracker de GitHub: <a href=\"https://github.com/stefan-niedermann/nextcloud-notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Puedes informar de errores, proponer mejoras y pedir características en el tracker de GitHub: <a href="https://github.com/stefan-niedermann/nextcloud-notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Licencia de la aplicación</string>
     <string name="about_app_license">Esta aplicación está bajo la Licencia Pública General GNU v3+.</string>
     <string name="about_app_license_button">Ver licencia</string>
     <string name="about_app_icon_disclaimer_title">Icono de la app</string>
-    <string name="about_app_icon_disclaimer"><p>Icono original por <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> en <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Icono original por <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> en <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Iconos</string>
-    <string name="about_icons_disclaimer"><p>Todos los demás iconos usados por esta app son <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">iconos Material Design</a> hechos por Google Inc. y licenciados bajo una licencia Creative Commons.</p></string>
+    <string name="about_icons_disclaimer"><p>Todos los demás iconos usados por esta app son <a href="https://materialdesignicons.com/" title="Link to Website">iconos Material Design</a> hechos por Google Inc. y licenciados bajo una licencia Creative Commons.</p></string>
 
     <string name="about_credits_tab_title">Créditos</string>
     <string name="about_contribution_tab_title">Contribución</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Zerbitzaria</string>
     <string name="settings_url">Zerbitzariaren helbidea</string>
     <string name="settings_url_check_description">Erakusten du ea helbideari ping egin daiteken</string>
-    <string name="settings_url_warn_http">ERNE: \"http\" ez da segurua. Mesedez, erabili \"https\".</string>
+    <string name="settings_url_warn_http">ERNE: "http" ez da segurua. Mesedez, erabili "https".</string>
     <string name="settings_username">Erabiltzaile izena</string>
     <string name="settings_password">Pasahitza</string>
     <string name="settings_password_check_description">Erakusten du kredentzialak zuzenak diren.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Serbia), ageru (Frantzesa (Frantzia)), proninyaroslav (Errusiera), mist (Txekiera)</string>
     <string name="about_testers_title">Frogatzaileak</string>
     <string name="about_source_title">Iturburu-kodea</string>
-    <string name="about_source">Proiektu hau GitHub-en ostatatuta dago: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Proiektu hau GitHub-en ostatatuta dago: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Arazoak</string>
-    <string name="about_issues">GitHub-en akatsak salatu, hobekuntzak proposatu eta ezaugarri berriak eskatu ditzakezu hurrengo harian: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">GitHub-en akatsak salatu, hobekuntzak proposatu eta ezaugarri berriak eskatu ditzakezu hurrengo harian: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Aplikazio lizentzia</string>
     <string name="about_app_license">Aplikazio hau GNU GENERAL PUBLIC LICENSE v3+ lizentziapean dago.</string>
     <string name="about_app_license_button">Lizentzia ikusi</string>
     <string name="about_app_icon_disclaimer_title">Aplikazio irudia</string>
-    <string name="about_app_icon_disclaimer"><p>Jatorrizko irudia<a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> -ek egin du <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a>-tik</p></string>
+    <string name="about_app_icon_disclaimer"><p>Jatorrizko irudia<a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> -ek egin du <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a>-tik</p></string>
     <string name="about_icons_disclaimer_title">Irudiak</string>
-    <string name="about_icons_disclaimer"><p>Aplikazio honetan erabilitako beste irudi gustiak <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Irudiak</a> dira, Google Inc.-ek eginak eta Creative Commons Lizentziapean.</p></string>
+    <string name="about_icons_disclaimer"><p>Aplikazio honetan erabilitako beste irudi gustiak <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Irudiak</a> dira, Google Inc.-ek eginak eta Creative Commons Lizentziapean.</p></string>
 
     <string name="about_credits_tab_title">Kredituak</string>
     <string name="about_contribution_tab_title">Kontribuzio</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Peladen</string>
     <string name="settings_url">Alamat peladen</string>
     <string name="settings_url_check_description">Tampilkan jika alamat dapat diping.</string>
-    <string name="settings_url_warn_http">PERHATIAN: \"http\" tidak aman. Harap gunakan \"https\".</string>
+    <string name="settings_url_warn_http">PERHATIAN: "http" tidak aman. Harap gunakan "https".</string>
     <string name="settings_username">Nama pengguna</string>
     <string name="settings_password">Sandi</string>
     <string name="settings_password_check_description">Tampilkan jika sandi benar</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Serbia), ageru (Perancis (Perancis)), proninyaroslav (Rusia), mist (Chechnya)</string>
     <string name="about_testers_title">Penguji</string>
     <string name="about_source_title">Kode sumber</string>
-    <string name="about_source">Proyek ini dihosting di GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Proyek ini dihosting di GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Isu</string>
-    <string name="about_issues">Anda dapat melaporkan kutu, meningkatkan proposal dan permintaan fitur di pelacak isu GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Anda dapat melaporkan kutu, meningkatkan proposal dan permintaan fitur di pelacak isu GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Lisensi apl</string>
     <string name="about_app_license">Aplikasi ini dilisensikan dibawah GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Lihat lisensi</string>
     <string name="about_app_icon_disclaimer_title">Ikon apl</string>
-    <string name="about_app_icon_disclaimer"><p>Ikon asli dibuat oleh <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> dari <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Ikon asli dibuat oleh <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> dari <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikon</string>
-    <string name="about_icons_disclaimer"><p>Semua ikon selanjutnya yang digunakan apl ini adalah <a href=\"https://materialdesignicons.com/\" title=\"Tautan ke Situs\">Ikon Material Design</a> dibuat oleh Google Inc. dan dilisensikan dibawah Lisensi Creative Commons</p></string>
+    <string name="about_icons_disclaimer"><p>Semua ikon selanjutnya yang digunakan apl ini adalah <a href="https://materialdesignicons.com/" title="Tautan ke Situs">Ikon Material Design</a> dibuat oleh Google Inc. dan dilisensikan dibawah Lisensi Creative Commons</p></string>
 
     <string name="about_credits_tab_title">Kredit</string>
     <string name="about_contribution_tab_title">Kontribusi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -36,7 +36,7 @@
     <string name="settings_server">Server</string>
     <string name="settings_url">Indirizzo del server</string>
     <string name="settings_url_check_description">Mostra se l\'indirizzo può rispondere al ping.</string>
-    <string name="settings_url_warn_http">AVVISO: \"http\" non è sicuro. Utlizza \"https\".</string>
+    <string name="settings_url_warn_http">AVVISO: "http" non è sicuro. Utlizza "https".</string>
     <string name="settings_username">Nome utente</string>
     <string name="settings_password">Password</string>
     <string name="settings_password_check_description">Mostra se le credenziali sono corrette.</string>
@@ -70,7 +70,7 @@
     <string name="about_app_license">Questa applicazione è rilasciata nei termini della licenza GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Visualizza licenza</string>
     <string name="about_app_icon_disclaimer_title">Icona applicazione</string>
-    <string name="about_app_icon_disclaimer"><p>Icona originale creata da <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> da <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Icona originale creata da <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> da <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Icone</string>
     <string name="about_credits_tab_title">Riconoscimenti</string>
     <string name="about_contribution_tab_title">Contributi</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Serveris</string>
     <string name="settings_url">Servera adrese</string>
     <string name="settings_url_check_description">Parāda, ja adresi var nopingot.</string>
-    <string name="settings_url_warn_http">BRĪDINĀJUMS: \"http\" ir nedrošs, lietojiet \"https\" !!!</string>
+    <string name="settings_url_warn_http">BRĪDINĀJUMS: "http" ir nedrošs, lietojiet "https" !!!</string>
     <string name="settings_username">Lietotājvārds</string>
     <string name="settings_password">Parole</string>
     <string name="settings_password_check_description">Rāda, vai akreditācijas dati ir pareizi.</string>
@@ -71,12 +71,12 @@
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testētāji</string>
     <string name="about_source_title">Izejas kods</string>
-    <string name="about_source">Šis projekts atrodas uz GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Šis projekts atrodas uz GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_app_license_title">Programmas licence</string>
     <string name="about_app_license">Šī lietojumprogramma tiek licencēta zem GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Skatīt licenci</string>
     <string name="about_app_icon_disclaimer_title">Programmas ikona</string>
-    <string name="about_app_icon_disclaimer"><p>Orģinālās ikonas izveodojis <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> no <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Orģinālās ikonas izveodojis <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> no <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikonas</string>
     <string name="about_credits_tab_title">Kredīti</string>
     <string name="about_license_tab_title">Licence</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Tjener</string>
     <string name="settings_url">Tjeneradresse</string>
     <string name="settings_url_check_description">Vises hvis adressen kan pinges.</string>
-    <string name="settings_url_warn_http">ADVARSEL: \"http\" er usikker. Vennligst bruk \"https\".</string>
+    <string name="settings_url_warn_http">ADVARSEL: "http" er usikker. Vennligst bruk "https".</string>
     <string name="settings_username">Brukernavn</string>
     <string name="settings_password">Passord</string>
     <string name="settings_password_check_description">Vis hvis påloggingsinformasjon er riktig.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">Sølve_Salvesen (norsk bokmål)</string>
     <string name="about_testers_title">Testere</string>
     <string name="about_source_title">Kildekode</string>
-    <string name="about_source">Dette prosjektet ligger på GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dette prosjektet ligger på GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Feil</string>
-    <string name="about_issues">Du kan rapportere feil, forbedringforslag og funksjonønsker på GitHub saksporeren: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Du kan rapportere feil, forbedringforslag og funksjonønsker på GitHub saksporeren: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Lisens</string>
     <string name="about_app_license">Dette programmet er lisensiert under GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Vis lisens</string>
     <string name="about_app_icon_disclaimer_title">App ikon</string>
-    <string name="about_app_icon_disclaimer"><p>Orginalt ikon laget av <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> fra <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Orginalt ikon laget av <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> fra <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikoner</string>
-    <string name="about_icons_disclaimer"><p>Alle andre ikoner brukt av denne app\'en er <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Icons</a> laget av Google Inc. og lisensiert under Creative Commons License.</p></string>
+    <string name="about_icons_disclaimer"><p>Alle andre ikoner brukt av denne app\'en er <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> laget av Google Inc. og lisensiert under Creative Commons License.</p></string>
 
     <string name="about_contribution_tab_title">Bidragsytere</string>
     <string name="about_license_tab_title">Lisens</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Server</string>
     <string name="settings_url">Server adres</string>
     <string name="settings_url_check_description">Ping mogelijkheid van adres weergeven.</string>
-    <string name="settings_url_warn_http">WAARSCHUWING: \"http\" in niet veilig. Gebruik \"https\".</string>
+    <string name="settings_url_warn_http">WAARSCHUWING: "http" in niet veilig. Gebruik "https".</string>
     <string name="settings_username">Gebruikersnaam</string>
     <string name="settings_password">Wachtwoord</string>
     <string name="settings_password_check_description">Certificaat correctheid weergeven.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Servisch), ageru (Français (Frans)), proninyaroslav (Russisch), mist (Tsjechisch)</string>
     <string name="about_testers_title">Testers</string>
     <string name="about_source_title">Broncode</string>
-    <string name="about_source">Dit is een GitHub project: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dit is een GitHub project: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Kwesties</string>
-    <string name="about_issues">Je kan een bug, wijzigingen of functie verzoek melden bij de GitHub issue tracker: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Je kan een bug, wijzigingen of functie verzoek melden bij de GitHub issue tracker: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">App licentie</string>
     <string name="about_app_license">Deze applicatie valt onder de GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Licentie weergeven</string>
     <string name="about_app_icon_disclaimer_title">App pictogram</string>
-    <string name="about_app_icon_disclaimer"><p>Het originele pictogram is gemaakt door <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> van <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Het originele pictogram is gemaakt door <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> van <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">pictogram</string>
-    <string name="about_icons_disclaimer"><p>Alle pictogram\'s gebruikt door deze app zijn <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Materiaal ontwerp pictogram\'s</a> gemaakt door Google Inc. en vallen onder de Creatieve Content Licentie.</p></string>
+    <string name="about_icons_disclaimer"><p>Alle pictogram\'s gebruikt door deze app zijn <a href="https://materialdesignicons.com/" title="Link to Website">Materiaal ontwerp pictogram\'s</a> gemaakt door Google Inc. en vallen onder de Creatieve Content Licentie.</p></string>
 
     <string name="about_credits_tab_title">Credits</string>
     <string name="about_contribution_tab_title">Bijdrage</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Serwer</string>
     <string name="settings_url">Adres serwera</string>
     <string name="settings_url_check_description">Pokazuje czy adres może zostać pingnięty.</string>
-    <string name="settings_url_warn_http">OSTRZEŻENIE: \"http\" nie jest bezpieczne. Proszę użyć \"https\".</string>
+    <string name="settings_url_warn_http">OSTRZEŻENIE: "http" nie jest bezpieczne. Proszę użyć "https".</string>
     <string name="settings_username">Nazwa użytkownika</string>
     <string name="settings_password">Hasło</string>
     <string name="settings_password_check_description">Pokazuje czy dane dostępowe są poprawne.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testerzy</string>
     <string name="about_source_title">Kod źródłowy</string>
-    <string name="about_source">Ten projekt jest hostowany na GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Ten projekt jest hostowany na GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Problemy</string>
-    <string name="about_issues">Możesz zgłaszać błędy, propozycje rozbudowy lub prośby o nowe funkcjonalności na GitHubie: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Możesz zgłaszać błędy, propozycje rozbudowy lub prośby o nowe funkcjonalności na GitHubie: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Licencja aplikacji</string>
     <string name="about_app_license">Aplikacja jest chroniona licencją GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Zobacz licencję</string>
     <string name="about_app_icon_disclaimer_title">Ikona aplikacji</string>
-    <string name="about_app_icon_disclaimer"><p>Oryginalna ikona została wykonana przez <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jana C. Borchardta</a> z <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Oryginalna ikona została wykonana przez <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jana C. Borchardta</a> z <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikony</string>
-    <string name="about_icons_disclaimer"><p>Pozostałe ikony użyte w aplikacji są <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Ikonami Material Design</a> wykonanymi przez Google Inc. i są chronione licencją Creative Commons License.</p></string>
+    <string name="about_icons_disclaimer"><p>Pozostałe ikony użyte w aplikacji są <a href="https://materialdesignicons.com/" title="Link to Website">Ikonami Material Design</a> wykonanymi przez Google Inc. i są chronione licencją Creative Commons License.</p></string>
 
     <string name="about_credits_tab_title">O</string>
     <string name="about_contribution_tab_title">Wkład</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Servidor</string>
     <string name="settings_url">Endereço do servidor</string>
     <string name="settings_url_check_description">Mostra se o endereço pode ser pingado.</string>
-    <string name="settings_url_warn_http">AVISO: \"http\" é inseguro. Utilize \"https\".</string>
+    <string name="settings_url_warn_http">AVISO: "http" é inseguro. Utilize "https".</string>
     <string name="settings_username">Nome de usuário</string>
     <string name="settings_password">Senha</string>
     <string name="settings_password_check_description">Mostra se as credenciais estão corretas.</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Serbe), ageru (Francês (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testadores</string>
     <string name="about_source_title">Código fonte</string>
-    <string name="about_source">Este projeto está hospedado no GitHub:<a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Este projeto está hospedado no GitHub:<a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Problemas</string>
-    <string name="about_issues">Você pode relatar bugs, propostas de aprimoramento e solicitações de recursos no rastreador de problemas do GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Você pode relatar bugs, propostas de aprimoramento e solicitações de recursos no rastreador de problemas do GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Licença de aplicativo</string>
     <string name="about_app_license">Esta aplicação está licenciada sob a GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Ver licença</string>
     <string name="about_app_icon_disclaimer_title">Ícone do aplicativo</string>
-    <string name="about_app_icon_disclaimer"><p>Ícone original feito por<a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> da <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Ícone original feito por<a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> da <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ícones</string>
-    <string name="about_icons_disclaimer"><p>Todos os outros ícones usados por este aplicativo são <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Icons</a>Feita pela Google Inc. e licenciada sob uma licença Creative Commons.</p></string>
+    <string name="about_icons_disclaimer"><p>Todos os outros ícones usados por este aplicativo são <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a>Feita pela Google Inc. e licenciada sob uma licença Creative Commons.</p></string>
 
     <string name="about_credits_tab_title">Créditos</string>
     <string name="about_contribution_tab_title">Contribuição</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Server</string>
     <string name="settings_url">Adresa servera</string>
     <string name="settings_url_check_description">Ukáže či je adresa pingnuteľná.</string>
-    <string name="settings_url_warn_http">VAROVANIE: \"http\" nie je bezpečné. Použite prosím \"https\".</string>
+    <string name="settings_url_warn_http">VAROVANIE: "http" nie je bezpečné. Použite prosím "https".</string>
     <string name="settings_username">Meno používateľa</string>
     <string name="settings_password">Heslo</string>
     <string name="settings_password_check_description">Zobrazí či sú správne prihlasovacie údaje.</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -38,7 +38,7 @@
     <string name="settings_server">Serveri</string>
     <string name="settings_url">Adresa e serverit</string>
     <string name="settings_url_check_description">Tregon nëse adresa po bëhet ping</string>
-    <string name="settings_url_warn_http">PARALAJMËRIM: \"http\" nuk është e sigurt. Ju lutemi përdorni \"https\".</string>
+    <string name="settings_url_warn_http">PARALAJMËRIM: "http" nuk është e sigurt. Ju lutemi përdorni "https".</string>
     <string name="settings_username">Emri i përdoruesit</string>
     <string name="settings_password">Fjalëkalimi</string>
     <string name="settings_password_check_description">Tregon nëse kredencialet janë të sakta</string>
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testuesit</string>
     <string name="about_source_title">Kodi burim</string>
-    <string name="about_source">Ky projekt ruhet në GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Ky projekt ruhet në GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Çështjet</string>
-    <string name="about_issues">Ju mund të raportoni buge, përmirësoni propozimet dhe të paraqisni propozime në gjurmuesin e çështjeve të GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Ju mund të raportoni buge, përmirësoni propozimet dhe të paraqisni propozime në gjurmuesin e çështjeve të GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Liçensa e aplikacionit</string>
     <string name="about_app_license">Ky aplikacion është liçensuar nën GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Trego liçensën</string>
     <string name="about_app_icon_disclaimer_title">Ikona e aplikacionit</string>
-    <string name="about_app_icon_disclaimer"><p>Ikona origjinale u bë nga <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> nga <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
+    <string name="about_app_icon_disclaimer"><p>Ikona origjinale u bë nga <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> nga <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikonat</string>
-    <string name="about_icons_disclaimer"><p>Të gjitha ikonat vijuese të përdorura nga ky aplikacion janë <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Ikona Material Design </a> të bëra nga Google Inc. dhe të liçensuara nën Liçensën Creative Commons.</p></string>
+    <string name="about_icons_disclaimer"><p>Të gjitha ikonat vijuese të përdorura nga ky aplikacion janë <a href="https://materialdesignicons.com/" title="Link to Website">Ikona Material Design </a> të bëra nga Google Inc. dhe të liçensuara nën Liçensën Creative Commons.</p></string>
 
     <string name="about_credits_tab_title">Kreditet</string>
     <string name="about_contribution_tab_title">Kontributi</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -74,16 +74,16 @@
     <string name="about_translators">pejakm (塞尔维亚语), ageru (Français (法语)), proninyaroslav (俄语), mist (捷克语)</string>
     <string name="about_testers_title">测试人员</string>
     <string name="about_source_title">源代码</string>
-    <string name="about_source">本项目托管在GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">本项目托管在GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">问题</string>
-    <string name="about_issues">你可以报告缺陷, 优化建议和特性要求在 GitHub 发布管理器: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">你可以报告缺陷, 优化建议和特性要求在 GitHub 发布管理器: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">应用授权</string>
     <string name="about_app_license">此程序通过GNU通用公共许可证V3+授权。</string>
     <string name="about_app_license_button">查看授权</string>
     <string name="about_app_icon_disclaimer_title">应用图标</string>
-    <string name="about_app_icon_disclaimer"><p>原始图标由 <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> 在 <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a> 创作的</p></string>
+    <string name="about_app_icon_disclaimer"><p>原始图标由 <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> 在 <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a> 创作的</p></string>
     <string name="about_icons_disclaimer_title">图标</string>
-    <string name="about_icons_disclaimer"><p>这个应用程序使用的所有更多的图标 <a href=\"https://materialdesignicons.com/\" title=\"链接站点\">材料设计图标</a> 由谷歌公司推出. 在知识共享协议下授权.</p></string>
+    <string name="about_icons_disclaimer"><p>这个应用程序使用的所有更多的图标 <a href="https://materialdesignicons.com/" title="链接站点">材料设计图标</a> 由谷歌公司推出. 在知识共享协议下授权.</p></string>
 
     <string name="about_credits_tab_title">致谢</string>
     <string name="about_contribution_tab_title">贡献</string>


### PR DESCRIPTION
* double-quotes don't need to be escaped within the xml-resource-files (currently the build will fail because the xml-resources can't be parsed properly due to these escapings)

* there are several language-resource-files/translations with missing entries; lint will complain about this and cancel the build