### PR TITLE
Fix and clear up translations

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/about/AboutFragmentContributingTab.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/about/AboutFragmentContributingTab.java
@@ -2,20 +2,21 @@ package it.niedermann.owncloud.notes.android.fragment.about;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.util.SupportUtil;
 
 public class AboutFragmentContributingTab extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_about_contribution_tab, container, false);
-        ((TextView) v.findViewById(R.id.about_source)).setMovementMethod(LinkMovementMethod.getInstance());
-        ((TextView) v.findViewById(R.id.about_issues)).setMovementMethod(LinkMovementMethod.getInstance());
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_source), R.string.about_source, getString(R.string.url_source));
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_issues), R.string.about_issues, getString(R.string.url_issues));
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_translate), R.string.about_translate, getString(R.string.url_translations));
         return v;
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/about/AboutFragmentCreditsTab.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/about/AboutFragmentCreditsTab.java
@@ -3,26 +3,27 @@ package it.niedermann.owncloud.notes.android.fragment.about;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.util.SupportUtil;
 
 public class AboutFragmentCreditsTab extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_about_credits_tab, container, false);
-        ((TextView) v.findViewById(R.id.about_maintainer)).setMovementMethod(LinkMovementMethod.getInstance());
         String versionName;
         try {
             versionName = "v"+getActivity().getPackageManager().getPackageInfo(getActivity().getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException e) {
             versionName = "(error)";
         }
-        ((TextView) v.findViewById(R.id.about_version)).setText(getString(R.string.about_version, versionName));
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_version), R.string.about_version, versionName);
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_maintainer), R.string.about_maintainer);
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_translators), R.string.about_translators_transifex, getString(R.string.url_translations));
         return v;
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/about/AboutFragmentLicenseTab.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/about/AboutFragmentLicenseTab.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,9 +11,9 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.util.SupportUtil;
 
 public class AboutFragmentLicenseTab extends Fragment {
-    public static final String GNU_GENERAL_PUBLIC_LICENSE = "https://github.com/stefan-niedermann/OwnCloud-Notes/blob/master/LICENSE";
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_about_license_tab, container, false);
@@ -22,11 +21,10 @@ public class AboutFragmentLicenseTab extends Fragment {
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(GNU_GENERAL_PUBLIC_LICENSE)));
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_license))));
             }
         });
-        ((TextView) v.findViewById(R.id.about_app_icon_disclaimer)).setMovementMethod(LinkMovementMethod.getInstance());
-        ((TextView) v.findViewById(R.id.about_icons_disclaimer)).setMovementMethod(LinkMovementMethod.getInstance());
+        SupportUtil.setHtml((TextView) v.findViewById(R.id.about_icons_disclaimer), R.string.about_icons_disclaimer, getString(R.string.about_app_icon_author));
         return v;
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/SupportUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/SupportUtil.java
@@ -1,0 +1,40 @@
+package it.niedermann.owncloud.notes.util;
+
+import android.os.Build;
+import android.text.Html;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.widget.TextView;
+
+/**
+ * Some helper functionality in alike the Android support library.
+ * Currently, it offers methods for working with HTML string resources.
+ */
+public class SupportUtil {
+
+    /**
+     * Creates a {@link Spanned} from a HTML string on all SDK versions.
+     * @see Html#fromHtml(String)
+     * @see Html#fromHtml(String, int)
+     * @param source Source string with HTML markup
+     * @return Spannable for using in a {@link TextView}
+     */
+    public static Spanned fromHtml(String source) {
+        if (Build.VERSION.SDK_INT >= 24) {
+            return Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            return Html.fromHtml(source);
+        }
+    }
+
+    /**
+     * Fills a {@link TextView} with HTML content and activates links in that {@link TextView}.
+     * @param view          The {@link TextView} which should be filled.
+     * @param stringId      The string resource containing HTML tags (escaped by <code>&lt;</code>)
+     * @param formatArgs    Arguments for the string resource.
+     */
+    public static void setHtml(TextView view, int stringId, Object... formatArgs) {
+        view.setText(SupportUtil.fromHtml(view.getResources().getString(stringId, formatArgs)));
+        view.setMovementMethod(LinkMovementMethod.getInstance());
+    }
+}

--- a/app/src/main/res/layout/fragment_about_contribution_tab.xml
+++ b/app/src/main/res/layout/fragment_about_contribution_tab.xml
@@ -38,5 +38,20 @@
             android:layout_height="wrap_content"
             android:padding="10dp"
             android:text="@string/about_issues" />
+
+        <TextView
+            android:id="@+id/about_translate_title"
+            style="?android:attr/listSeparatorTextViewStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/about_translate_title" />
+
+        <TextView
+            android:id="@+id/about_translate"
+            style="?android:attr/editTextPreferenceStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="10dp"
+            android:text="@string/about_translate" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_about_credits_tab.xml
+++ b/app/src/main/res/layout/fragment_about_credits_tab.xml
@@ -80,7 +80,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="10dp"
-            android:text="@string/about_translators" />
+            android:text="@string/about_translators_transifex" />
 
         <TextView
             android:id="@+id/about_testers_title"

--- a/app/src/main/res/layout/fragment_about_license_tab.xml
+++ b/app/src/main/res/layout/fragment_about_license_tab.xml
@@ -31,21 +31,6 @@
             android:text="@string/about_app_license_button" />
 
         <TextView
-            android:id="@+id/about_app_icon_disclaimer_title"
-            style="?android:attr/listSeparatorTextViewStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/about_app_icon_disclaimer_title" />
-
-        <TextView
-            android:id="@+id/about_app_icon_disclaimer"
-            style="?android:attr/editTextPreferenceStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="10dp"
-            android:text="@string/about_app_icon_disclaimer" />
-
-        <TextView
             android:id="@+id/about_icons_disclaimer_title"
             style="?android:attr/listSeparatorTextViewStyle"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-ca/plurals.xml
+++ b/app/src/main/res/values-ca/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d seleccionat</item>
-        <item quantity="other">%d seleccionats</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -14,8 +14,8 @@
     <string name="action_edit_cancel">Cancel·lar</string>
     <string name="action_about">Sobre</string>
     <string name="action_select_note">Selecciona una nota</string>
-    <string name="action_note_deleted">S\\\'ha esborrat la nota</string>
-    <string name="action_note_restored">S\\\'ha restaurat la nota</string>
+    <string name="action_note_deleted">S\'ha esborrat la nota</string>
+    <string name="action_note_restored">S\'ha restaurat la nota</string>
     <string name="action_undo">Des-fes</string>
     <string name="menu_delete">Esborrar</string>
     <string name="menu_copy">Copiar</string>
@@ -37,9 +37,9 @@
     <!-- Settings -->
     <string name="settings_server">Servidor</string>
     <string name="settings_url">Adreça del servidor</string>
-    <string name="settings_url_check_description">Mostra si es pot fer ping a l\\\'adreça</string>
+    <string name="settings_url_check_description">Mostra si es pot fer ping a l\'adreça</string>
     <string name="settings_url_warn_http">ATENCIÓ: \"http\" és insegur. Si us plau utilitzeu \"https\".</string>
-    <string name="settings_username">Nom d\\\'usuari</string>
+    <string name="settings_username">Nom d\'usuari</string>
     <string name="settings_password">Contrasenya</string>
     <string name="settings_password_check_description">Mostar si les credencials son correctes</string>
     <string name="settings_submit">Connecta</string>
@@ -55,9 +55,9 @@
     <string name="error_sync">Error en la sincronització: %1$s</string>
     <string name="error_invalid_login">Inici de sessió invàlid: %1$s</string>
     <string name="error_json">El servidor té les owncloud app activades?</string>
-    <string name="error_io">S\\\'ha trencat la connecció amb el servidor</string>
+    <string name="error_io">S\'ha trencat la connecció amb el servidor</string>
     <string name="error_no_network">No hi ha connexió a la xarxa</string>
-    <string name="error_server">L\\\'URL/Server conté errors</string>
+    <string name="error_server">L\'URL/Server conté errors</string>
     <string name="error_url_malformed">Adreça del servidor incorrecta</string>
     <string name="error_username_password_invalid">Usuari o contrasenya erroni</string>
 
@@ -67,20 +67,17 @@
 
     <!-- About -->
     <string name="about_version_title">Versió</string>
-    <string name="about_version">Esteu utilitzant <strong>%1$s</strong></string>
+    <string name="about_version">Esteu utilitzant &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Manteniment</string>
     <string name="about_developers_title">Desenvolupadors</string>
     <string name="about_translators_title">Traductors</string>
-    <string name="about_translators">pejakm (Serbi), ageru (Francès (França)), proninyaroslav (Rus), mist (txec)</string>
     <string name="about_testers_title">Provadors</string>
     <string name="about_source_title">Codi font</string>
-    <string name="about_source">Aquest projecte es troba a GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Aquest projecte es troba a GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Problemes</string>
-    <string name="about_app_license_title">Llicència de l\\\'aplicació</string>
+    <string name="about_app_license_title">Llicència de l\'aplicació</string>
     <string name="about_app_license">Aquesta aplicació està llicenciada sota GNU GENERAL PUBLIC LICENSE v3+</string>
     <string name="about_app_license_button">Veure llicència</string>
-    <string name="about_app_icon_disclaimer_title">Icona de l\\\'aplicació</string>
-    <string name="about_app_icon_disclaimer"><p>Icona original feta per <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> des de <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Icones</string>
     <string name="about_credits_tab_title">Crèdits</string>
     <string name="about_contribution_tab_title">Contribució</string>
@@ -88,4 +85,11 @@
 
     <string name="widget_all_notes_title">Totes les notes</string>
     <string name="widget_single_note_title">Una nota</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d seleccionat</item>
+        <item quantity="other">%d seleccionats</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-cs-rCZ/plurals.xml
+++ b/app/src/main/res/values-cs-rCZ/plurals.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d vybrán</item>
-        <item quantity="few">%d vybrány</item>
-        <item quantity="other">%d vybráno</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -67,28 +67,32 @@
 
     <!-- About -->
     <string name="about_version_title">Verze</string>
-    <string name="about_version">Právě používáte <strong>%1$s</strong></string>
+    <string name="about_version">Právě používáte &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Tvůrci</string>
     <string name="about_developers_title">Vývojáři</string>
     <string name="about_translators_title">Překladatelé</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testeři</string>
     <string name="about_source_title">Zdrojový kód</string>
-    <string name="about_source">Tento projekt je hostován na GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Tento projekt je hostován na GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Problémy</string>
-    <string name="about_issues">Chyby, nápady na vylepšení a nové funkce můžete nahlásit na GitHub issue tracker: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Chyby, nápady na vylepšení a nové funkce můžete nahlásit na GitHub issue tracker: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licence aplikace</string>
     <string name="about_app_license">Tato aplikace je licencována pod GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Zobrazit licenci</string>
-    <string name="about_app_icon_disclaimer_title">Ikona aplikace</string>
-    <string name="about_app_icon_disclaimer"><p>Originální ikonu vytvořil <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> z <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikony</string>
-    <string name="about_icons_disclaimer"><p>Všechny další ikony, které tato aplikace využívá jsou <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Icons</a> vytvořeno Google Inc. a licencováno pod Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Originální ikonu vytvořil %1$s&lt;/p>&lt;p>Všechny další ikony, které tato aplikace využívá jsou &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons&lt;/a> vytvořeno Google Inc. a licencováno pod Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">Zásluhy</string>
     <string name="about_contribution_tab_title">Příspěvek</string>
     <string name="about_license_tab_title">Licence</string>
 
     <string name="widget_all_notes_title">Všechny poznámky</string>
     <string name="widget_single_note_title">Jedna poznámka</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d vybrán</item>
+        <item quantity="few">%d vybrány</item>
+        <item quantity="other">%d vybráno</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-cs/plurals.xml
+++ b/app/src/main/res/values-cs/plurals.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d vybrán</item>
-        <item quantity="few">%d vybrány</item>
-        <item quantity="other">%d vybráno</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -55,28 +55,32 @@
 
     <!-- About -->
     <string name="about_version_title">Verze</string>
-    <string name="about_version">Právě používáte <strong>%1$s</strong></string>
+    <string name="about_version">Právě používáte &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Správce</string>
     <string name="about_developers_title">Vývojáři</string>
     <string name="about_translators_title">Překladatelé</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testeři</string>
     <string name="about_source_title">Source code</string>
-    <string name="about_source">Projekt je hostovaný na GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Projekt je hostovaný na GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Chyby</string>
-    <string name="about_issues">Chyby nebo nové vychytávky hlašte na GitHub issue tracker: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Chyby nebo nové vychytávky hlašte na GitHub issue tracker: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licence</string>
     <string name="about_app_license">Aplikace je licencovaná pod GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Zobrazit licenci</string>
-    <string name="about_app_icon_disclaimer_title">Ikona aplikace</string>
-    <string name="about_app_icon_disclaimer"><p>Původní návrh od <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> z <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikony</string>
-    <string name="about_icons_disclaimer"><p>Všechny další ikony, které tato aplikace využívá jsou <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> vytvořeno Google Inc. a licencováno pod Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Původní návrh od %1$s&lt;/p>&lt;p>Všechny další ikony, které tato aplikace využívá jsou &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons&lt;/a> vytvořeno Google Inc. a licencováno pod Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">Zásluhy</string>
     <string name="about_contribution_tab_title">Připěvatelé</string>
     <string name="about_license_tab_title">Licence</string>
 
     <string name="widget_all_notes_title">Všechny zápisky</string>
     <string name="widget_single_note_title">Jeden zápisek</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d vybrán</item>
+        <item quantity="few">%d vybrány</item>
+        <item quantity="other">%d vybráno</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-da/plurals.xml
+++ b/app/src/main/res/values-da/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d valgt</item>
-        <item quantity="other">%d selected</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -66,17 +66,21 @@
     <string name="about_translators_title">Oversættere</string>
     <string name="about_testers_title">Testere</string>
     <string name="about_source_title">Kildekode</string>
-    <string name="about_source">Dette projekt er hosted på GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dette projekt er hosted på GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">App licens</string>
     <string name="about_app_license">Denne applikation er licenseret under GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Vis licens</string>
-    <string name="about_app_icon_disclaimer_title">App ikon</string>
-    <string name="about_app_icon_disclaimer"><p>Det original ikon er lavet af <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> fra <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikoner</string>
-    <string name="about_icons_disclaimer"><p>Alle andre ikoner brugt i denne app er <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design ikoner</a> af Google Inc. licenseret under en Creative Commons Licens.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Det original ikon er lavet af %1$s&lt;/p>&lt;p>Alle andre ikoner brugt i denne app er &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design ikoner&lt;/a> af Google Inc. licenseret under en Creative Commons Licens.&lt;/p></string>
     <string name="about_credits_tab_title">Credits</string>
     <string name="about_license_tab_title">Licens</string>
 
     <string name="widget_all_notes_title">Alle noter</string>
-    </resources>
+    
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d valgt</item>
+        <item quantity="other">%d selected</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/values-de-rDE/plurals.xml
+++ b/app/src/main/res/values-de-rDE/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d ausgewählt</item>
-        <item quantity="other">%d ausgewählt</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Version</string>
-    <string name="about_version">Sie benutzen aktuell <strong>%1$s</strong></string>
+    <string name="about_version">Sie benutzen aktuell &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Maintainer</string>
     <string name="about_developers_title">Entwickler</string>
     <string name="about_translators_title">Übersetzer</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Tester</string>
     <string name="about_source_title">Quellcode</string>
-    <string name="about_source">Dieses Projekt ist auf GitHub gehosted: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dieses Projekt ist auf GitHub gehosted: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Tickets</string>
-    <string name="about_issues">Sie können Fehler, Verbesserungsvorschläge oder Wünsche für neue Funktionen im GitHub Ticket-System erfassen: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Sie können Fehler, Verbesserungsvorschläge oder Wünsche für neue Funktionen im GitHub Ticket-System erfassen: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">App Lizenz</string>
     <string name="about_app_license">Diese Applikation ist lizenziert unter der GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Lizenz ansehen</string>
-    <string name="about_app_icon_disclaimer_title">App-Icon</string>
-    <string name="about_app_icon_disclaimer"><p>Ursprüngliches Icon wurde erstellt von <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> auf <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Icons</string>
-    <string name="about_icons_disclaimer"><p>Alle weiteren Icons, die in dieser App verwendet werden, sind <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> von Google Inc. und unter einer Creative Commons License lizensiert.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Ursprüngliches Icon wurde erstellt von %1$s&lt;/p>&lt;p>Alle weiteren Icons, die in dieser App verwendet werden, sind &lt;a href=\"https://materialdesignicons.com/\">Material Design Icons&lt;/a> von Google Inc. und unter einer Creative Commons License lizensiert.&lt;/p></string>
     <string name="about_credits_tab_title">Credits</string>
     <string name="about_contribution_tab_title">Mitmachen</string>
     <string name="about_license_tab_title">Lizenz</string>
 
     <string name="widget_all_notes_title">Alle Notizen</string>
     <string name="widget_single_note_title">Eine Notiz</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-de/plurals.xml
+++ b/app/src/main/res/values-de/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d ausgewählt</item>
-        <item quantity="other">%d ausgewählt</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Version</string>
-    <string name="about_version">Sie benutzen aktuell <strong>%1$s</strong></string>
+    <string name="about_version">Sie benutzen aktuell &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Maintainer</string>
     <string name="about_developers_title">Entwickler</string>
     <string name="about_translators_title">Übersetzer</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Tester</string>
     <string name="about_source_title">Quellcode</string>
-    <string name="about_source">Dieses Projekt ist auf GitHub gehosted: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dieses Projekt ist auf GitHub gehosted: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Tickets</string>
-    <string name="about_issues">Sie können Fehler, Verbesserungsvorschläge oder Wünsche für neue Funktionen im GitHub Ticket-System erfassen: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Sie können Fehler, Verbesserungsvorschläge oder Wünsche für neue Funktionen im GitHub Ticket-System erfassen: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">App Lizenz</string>
     <string name="about_app_license">Diese Applikation ist lizenziert unter der GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Lizenz ansehen</string>
-    <string name="about_app_icon_disclaimer_title">App-Icon</string>
-    <string name="about_app_icon_disclaimer"><p>Ursprüngliches Icon wurde erstellt von <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> auf <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Icons</string>
-    <string name="about_icons_disclaimer"><p>Alle weiteren Icons, die in dieser App verwendet werden, sind <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> von Google Inc. und unter einer Creative Commons License lizensiert.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Ursprüngliches Icon wurde erstellt von %1$s&lt;/p>&lt;p>Alle weiteren Icons, die in dieser App verwendet werden, sind &lt;a href=\"https://materialdesignicons.com/\" title="Link to Website">Material Design Icons&lt;/a> von Google Inc. und unter einer Creative Commons License lizensiert.&lt;/p></string>
     <string name="about_credits_tab_title">Credits</string>
     <string name="about_contribution_tab_title">Mitmachen</string>
     <string name="about_license_tab_title">Lizenz</string>
 
     <string name="widget_all_notes_title">Alle Notizen</string>
     <string name="widget_single_note_title">Eine Notiz</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d ausgewählt</item>
+        <item quantity="other">%d ausgewählt</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-el/plurals.xml
+++ b/app/src/main/res/values-el/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d επιλέχθηκε</item>
-        <item quantity="other">%d επιλέχθηκαν</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -67,26 +67,29 @@
 
     <!-- About -->
     <string name="about_version_title">Έκδοση</string>
-    <string name="about_version">Προς το παρόν χρησιμοποιείτε <strong>%1$s</strong></string>
+    <string name="about_version">Προς το παρόν χρησιμοποιείτε &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Συντηρητής</string>
     <string name="about_developers_title">Προγραμματιστές</string>
     <string name="about_translators_title">Μεταφραστές</string>
-    <string name="about_translators">pejakm (Σέρβικα), ageru (Γαλλικά (France)), proninyaroslav (Ρώσικα), mist (Τσέχικα)</string>
     <string name="about_testers_title">Δοκιμαστές</string>
     <string name="about_source_title">Πηγαίος κώδικας</string>
     <string name="about_issues_title">Θεματα</string>
     <string name="about_app_license_title">Άδεια χρήσης εφαρμογής</string>
     <string name="about_app_license">Αυτή η εφαρμογή υπόκεινται στην άδεια χρήσης GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Προβολή άδειας χρήσης</string>
-    <string name="about_app_icon_disclaimer_title">Εικονίδιο εφαρμογής</string>
-    <string name="about_app_icon_disclaimer"><p>Το αυθεντικό εικονίδιο κατασκευάστηκε από τον <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> από το <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Εικονίδια</string>
-    <string name="about_icons_disclaimer"><p>Όλα τα υπόλοιπα εικονίδια που χρησιμοποιούνται από αυτή την εφαρμογή είναι <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Εικονίδια Υλικού Σχεδίασης</a> κατασκευασμένα από την Google Inc. και έχουν άδεια χρήσης: Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Το αυθεντικό εικονίδιο κατασκευάστηκε από τον %1$s&lt;/p>&lt;p>Όλα τα υπόλοιπα εικονίδια που χρησιμοποιούνται από αυτή την εφαρμογή είναι &lt;a href="https://materialdesignicons.com/" title="Link to Website">Εικονίδια Υλικού Σχεδίασης&lt;/a> κατασκευασμένα από την Google Inc. και έχουν άδεια χρήσης: Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">Μνεία</string>
     <string name="about_contribution_tab_title">Συνεισφορά</string>
     <string name="about_license_tab_title">Άδεια χρήσης</string>
 
     <string name="widget_all_notes_title">Όλες οι σημειώσεις</string>
     <string name="widget_single_note_title">Απλή σημείωση</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d επιλέχθηκε</item>
+        <item quantity="other">%d επιλέχθηκαν</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-es/plurals.xml
+++ b/app/src/main/res/values-es/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d seleccionado</item>
-        <item quantity="other">%d seleccionados</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Versión</string>
-    <string name="about_version">Está usando ahora <strong>%1$s</strong></string>
+    <string name="about_version">Está usando ahora &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Mantenedor</string>
     <string name="about_developers_title">Desarrolladores</string>
     <string name="about_translators_title">Traductores</string>
-    <string name="about_translators">pejakm (serbio), ageru (Francés [Francia]), proninyaroslav (ruso), mist (checo)</string>
     <string name="about_testers_title">Testers</string>
     <string name="about_source_title">Código fuente</string>
-    <string name="about_source">Este proyecto se aloja en GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/nextcloud-notes/</a></string>
+    <string name="about_source">Este proyecto se aloja en GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Problemas</string>
-    <string name="about_issues">Puedes informar de errores, proponer mejoras y pedir características en el tracker de GitHub: <a href=\"https://github.com/stefan-niedermann/nextcloud-notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Puedes informar de errores, proponer mejoras y pedir características en el tracker de GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licencia de la aplicación</string>
     <string name="about_app_license">Esta aplicación está bajo la Licencia Pública General GNU v3+.</string>
     <string name="about_app_license_button">Ver licencia</string>
-    <string name="about_app_icon_disclaimer_title">Icono de la app</string>
-    <string name="about_app_icon_disclaimer"><p>Icono original por <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> en <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Iconos</string>
-    <string name="about_icons_disclaimer"><p>Todos los demás iconos usados por esta app son <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">iconos Material Design</a> hechos por Google Inc. y licenciados bajo una licencia Creative Commons.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Icono original por %1$s&lt;/p>&lt;p>Todos los demás iconos usados por esta app son &lt;a href="https://materialdesignicons.com/" title="Link to Website">iconos Material Design&lt;/a> hechos por Google Inc. y licenciados bajo una licencia Creative Commons.&lt;/p></string>
     <string name="about_credits_tab_title">Créditos</string>
     <string name="about_contribution_tab_title">Contribución</string>
     <string name="about_license_tab_title">Licencia</string>
 
     <string name="widget_all_notes_title">Todas las notas</string>
     <string name="widget_single_note_title">Nota única</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d seleccionado</item>
+        <item quantity="other">%d seleccionados</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -67,24 +67,20 @@
 
     <!-- About -->
     <string name="about_version_title">Vertsioa</string>
-    <string name="about_version">Une honetan <strong>%1$s</strong> erabiltzen ari zara</string>
+    <string name="about_version">Une honetan &lt;strong>%1$s&lt;/strong> erabiltzen ari zara</string>
     <string name="about_maintainer_title">Mantentzailea</string>
     <string name="about_developers_title">Garatzaileak</string>
     <string name="about_translators_title">Itzultzaileak</string>
-    <string name="about_translators">pejakm (Serbia), ageru (Frantzesa (Frantzia)), proninyaroslav (Errusiera), mist (Txekiera)</string>
     <string name="about_testers_title">Frogatzaileak</string>
     <string name="about_source_title">Iturburu-kodea</string>
-    <string name="about_source">Proiektu hau GitHub-en ostatatuta dago: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Proiektu hau GitHub-en ostatatuta dago: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Arazoak</string>
-    <string name="about_issues">GitHub-en akatsak salatu, hobekuntzak proposatu eta ezaugarri berriak eskatu ditzakezu hurrengo harian: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">GitHub-en akatsak salatu, hobekuntzak proposatu eta ezaugarri berriak eskatu ditzakezu hurrengo harian: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Aplikazio lizentzia</string>
     <string name="about_app_license">Aplikazio hau GNU GENERAL PUBLIC LICENSE v3+ lizentziapean dago.</string>
     <string name="about_app_license_button">Lizentzia ikusi</string>
-    <string name="about_app_icon_disclaimer_title">Aplikazio irudia</string>
-    <string name="about_app_icon_disclaimer"><p>Jatorrizko irudia<a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> -ek egin du <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a>-tik</p></string>
     <string name="about_icons_disclaimer_title">Irudiak</string>
-    <string name="about_icons_disclaimer"><p>Aplikazio honetan erabilitako beste irudi gustiak <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Irudiak</a> dira, Google Inc.-ek eginak eta Creative Commons Lizentziapean.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Jatorrizko irudia%1$s-tik&lt;/p>&lt;p>Aplikazio honetan erabilitako beste irudi gustiak &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design Irudiak&lt;/a> dira, Google Inc.-ek eginak eta Creative Commons Lizentziapean.&lt;/p></string>
     <string name="about_credits_tab_title">Kredituak</string>
     <string name="about_contribution_tab_title">Kontribuzio</string>
     <string name="about_license_tab_title">Lizentzia</string>

--- a/app/src/main/res/values-fr/plurals.xml
+++ b/app/src/main/res/values-fr/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d sélectionnée</item>
-        <item quantity="other">%d sélectionnées</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Version</string>
-    <string name="about_version">Vous utilisez actuellement la <strong>%1$s</strong></string>
+    <string name="about_version">Vous utilisez actuellement la &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Responsable</string>
     <string name="about_developers_title">Developpeurs</string>
     <string name="about_translators_title">Traducteurs</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testeurs</string>
     <string name="about_source_title">Code source</string>
-    <string name="about_source">Ce projet est hébergé sur GitHub : <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Ce projet est hébergé sur GitHub : &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Bugs</string>
-    <string name="about_issues">Vous pouvez signaler les bugs ainsi que vos propositions ou demandes d\'amélioration dans le gestionnaire de bugs de GitHub : <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Vous pouvez signaler les bugs ainsi que vos propositions ou demandes d\'amélioration dans le gestionnaire de bugs de GitHub : &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licence de l\'App</string>
     <string name="about_app_license">Cette application est licenciée selon les termes de la GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Voir la licence</string>
-    <string name="about_app_icon_disclaimer_title">Icône de l\'app</string>
-    <string name="about_app_icon_disclaimer"><p>Icône originale créée par <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> disponible <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="ownCloud Notes app icon on GitHub">sur GitHub</a>.</p></string>
     <string name="about_icons_disclaimer_title">Icônes</string>
-    <string name="about_icons_disclaimer"><p>Toutes les autres icônes utilisées par cette app sont des <a href="https://materialdesignicons.com/" title="Lien vers le site web">Material Design Icons</a> créées par Google Inc. et licenciées selon les termes de la Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Icône originale créée par %1$s.&lt;/p>&lt;p>Toutes les autres icônes utilisées par cette app sont des &lt;a href="https://materialdesignicons.com/" title="Lien vers le site web">Material Design Icons&lt;/a> créées par Google Inc. et licenciées selon les termes de la Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">Crédits</string>
     <string name="about_contribution_tab_title">Contributions</string>
     <string name="about_license_tab_title">Licence</string>
 
     <string name="widget_all_notes_title">Toutes les notes</string>
     <string name="widget_single_note_title">Une seule note</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d sélectionnée</item>
+        <item quantity="other">%d sélectionnées</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals -->
     <plurals name="ab_selected">
         <item quantity="one">%d kiválasztott</item>
         <item quantity="other">%d kiválasztott</item>

--- a/app/src/main/res/values-hy/plurals.xml
+++ b/app/src/main/res/values-hy/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d ընտրված է</item>
-        <item quantity="other">%d ընտրված է</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -54,26 +54,29 @@
 
     <!-- About -->
     <string name="about_version_title">տարբերակ</string>
-    <string name="about_version">դուք օգտագործում եք <strong>%1$s</strong></string>
+    <string name="about_version">դուք օգտագործում եք &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">ղեկավար</string>
     <string name="about_developers_title">ծրագրավորող</string>
     <string name="about_translators_title">թարգմանիչ</string>
-    <string name="about_translators">Արթուր Դավթյան, ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">թեսթավորող</string>
     <string name="about_source_title">ծրագրի կոդը</string>
-    <string name="about_source">ծրագիրը տեղադրված է GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">ծրագիրը տեղադրված է GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">հայց</string>
-    <string name="about_issues">բոլոր առաջարկները կարող եք ներկայացնել GitHub հայցեր բաժնում: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">բոլոր առաջարկները կարող եք ներկայացնել GitHub հայցեր բաժնում: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">ծրագրի լիցենզիան</string>
     <string name="about_app_license">տվյալ ծրագիրը լիցենզավորված է GNU GENERAL PUBLIC LICENSE v3+ կողմից.</string>
     <string name="about_app_license_button">տեսնել լիցենզիան </string>
-    <string name="about_app_icon_disclaimer_title">ծրագրի լոգոտիպը</string>
-    <string name="about_app_icon_disclaimer"><p>նախնական լոգոտիպը ստեղծված է<a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> մեջ <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">լոգոտիպներ</string>
-    <string name="about_icons_disclaimer"><p>բոլոր մյուս լոգոտիպերը, որոնք օգտագործվում են տվյալ ծրագրում լիցենզավորված են <a href="https://materialdesignicons.com/" title="Link to Website">Material Design լոգոտիպեր</a>  Creative Commons License կողմից.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>նախնական լոգոտիպը ստեղծված է%1$s&lt;/p>&lt;p>բոլոր մյուս լոգոտիպերը, որոնք օգտագործվում են տվյալ ծրագրում լիցենզավորված են &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design լոգոտիպեր&lt;/a>  Creative Commons License կողմից.&lt;/p></string>
     <string name="about_credits_tab_title">անվանացանկ</string>
     <string name="about_contribution_tab_title">մասնակցել</string>
     <string name="about_license_tab_title">լիցենզիա</string>
 
-    </resources>
+    
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d ընտրված է</item>
+        <item quantity="other">%d ընտրված է</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals -->
     <plurals name="ab_selected">
         <item quantity="one">%d selectionate</item>
         <item quantity="other">%d selectionate</item>

--- a/app/src/main/res/values-id/plurals.xml
+++ b/app/src/main/res/values-id/plurals.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="other">%d terpilih</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -67,28 +67,30 @@
 
     <!-- About -->
     <string name="about_version_title">Versi</string>
-    <string name="about_version">Anda saat ini menggunakan <strong>%1$s</strong></string>
+    <string name="about_version">Anda saat ini menggunakan &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Pengelola</string>
     <string name="about_developers_title">Pengembang</string>
     <string name="about_translators_title">Penerjemah</string>
-    <string name="about_translators">pejakm (Serbia), ageru (Perancis (Perancis)), proninyaroslav (Rusia), mist (Chechnya)</string>
     <string name="about_testers_title">Penguji</string>
     <string name="about_source_title">Kode sumber</string>
-    <string name="about_source">Proyek ini dihosting di GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Proyek ini dihosting di GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Isu</string>
-    <string name="about_issues">Anda dapat melaporkan kutu, meningkatkan proposal dan permintaan fitur di pelacak isu GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Anda dapat melaporkan kutu, meningkatkan proposal dan permintaan fitur di pelacak isu GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Lisensi apl</string>
     <string name="about_app_license">Aplikasi ini dilisensikan dibawah GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Lihat lisensi</string>
-    <string name="about_app_icon_disclaimer_title">Ikon apl</string>
-    <string name="about_app_icon_disclaimer"><p>Ikon asli dibuat oleh <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> dari <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikon</string>
-    <string name="about_icons_disclaimer"><p>Semua ikon selanjutnya yang digunakan apl ini adalah <a href=\"https://materialdesignicons.com/\" title=\"Tautan ke Situs\">Ikon Material Design</a> dibuat oleh Google Inc. dan dilisensikan dibawah Lisensi Creative Commons</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Ikon asli dibuat oleh %1$s&lt;/p>&lt;p>Semua ikon selanjutnya yang digunakan apl ini adalah &lt;a href="https://materialdesignicons.com/" title="Tautan ke Situs">Ikon Material Design&lt;/a> dibuat oleh Google Inc. dan dilisensikan dibawah Lisensi Creative Commons&lt;/p></string>
     <string name="about_credits_tab_title">Kredit</string>
     <string name="about_contribution_tab_title">Kontribusi</string>
     <string name="about_license_tab_title">Lisensi</string>
 
     <string name="widget_all_notes_title">Semua catatan</string>
     <string name="widget_single_note_title">Satu catatan</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="other">%d terpilih</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals -->
     <plurals name="ab_selected">
         <item quantity="one">%d valið</item>
         <item quantity="other">%d valið</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -59,18 +59,15 @@
 
     <!-- About -->
     <string name="about_version_title">Versione</string>
-    <string name="about_version">Stai utilizzando <strong>%1$s</strong></string>
+    <string name="about_version">Stai utilizzando &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Responsabile</string>
     <string name="about_developers_title">Sviluppatori</string>
     <string name="about_translators_title">Traduttori</string>
-    <string name="about_translators">pejakm (serbo), ageru (francese (Francia)), proninyaroslav (russo), mist (ceco)</string>
     <string name="about_source_title">Codice sorgente</string>
     <string name="about_issues_title">Problemi</string>
     <string name="about_app_license_title">Licenza applicazione</string>
     <string name="about_app_license">Questa applicazione è rilasciata nei termini della licenza GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Visualizza licenza</string>
-    <string name="about_app_icon_disclaimer_title">Icona applicazione</string>
-    <string name="about_app_icon_disclaimer"><p>Icona originale creata da <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> da <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Icone</string>
     <string name="about_credits_tab_title">Riconoscimenti</string>
     <string name="about_contribution_tab_title">Contributi</string>
@@ -78,4 +75,11 @@
 
     <string name="widget_all_notes_title">Tutte le note</string>
     <string name="widget_single_note_title">Nota singola</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d selezionata</item>
+        <item quantity="other">%d selezionate</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ja-rJP/plurals.xml
+++ b/app/src/main/res/values-ja-rJP/plurals.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="other">%d選択されています</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals -->
     <plurals name="ab_selected">
-        <item quantity="one">%d selezionata</item>
-        <item quantity="other">%d selezionate</item>
+        <item quantity="other">%d選択されています</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-lv/plurals.xml
+++ b/app/src/main/res/values-lv/plurals.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="zero">%d atlasīts</item>
-        <item quantity="one">%d atlasīts</item>
-        <item quantity="other">%d atlasīts</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -64,23 +64,28 @@
 
     <!-- About -->
     <string name="about_version_title">Versija</string>
-    <string name="about_version">Jūs šobrīd izmantojat <strong>%1$s</strong></string>
+    <string name="about_version">Jūs šobrīd izmantojat &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Uzturētājs</string>
     <string name="about_developers_title">Izstrādātāji</string>
     <string name="about_translators_title">Tulkotāji</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testētāji</string>
     <string name="about_source_title">Izejas kods</string>
-    <string name="about_source">Šis projekts atrodas uz GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Šis projekts atrodas uz GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Programmas licence</string>
     <string name="about_app_license">Šī lietojumprogramma tiek licencēta zem GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Skatīt licenci</string>
-    <string name="about_app_icon_disclaimer_title">Programmas ikona</string>
-    <string name="about_app_icon_disclaimer"><p>Orģinālās ikonas izveodojis <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> no <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikonas</string>
     <string name="about_credits_tab_title">Kredīti</string>
     <string name="about_license_tab_title">Licence</string>
 
     <string name="widget_all_notes_title">Visas piezīmes</string>
     <string name="widget_single_note_title">Viena piezīme</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="zero">%d atlasīts</item>
+        <item quantity="one">%d atlasīts</item>
+        <item quantity="other">%d atlasīts</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-nb-rNO/plurals.xml
+++ b/app/src/main/res/values-nb-rNO/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d valgt</item>
-        <item quantity="other">%d valgte</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -67,27 +67,30 @@
 
     <!-- About -->
     <string name="about_version_title">Versjon</string>
-    <string name="about_version">Du bruker <strong>%1$s</strong></string>
+    <string name="about_version">Du bruker &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Vedlikeholder</string>
     <string name="about_developers_title">Utvikler</string>
     <string name="about_translators_title">Oversetter</string>
-    <string name="about_translators">Sølve_Salvesen (norsk bokmål)</string>
     <string name="about_testers_title">Testere</string>
     <string name="about_source_title">Kildekode</string>
-    <string name="about_source">Dette prosjektet ligger på GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dette prosjektet ligger på GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Feil</string>
-    <string name="about_issues">Du kan rapportere feil, forbedringforslag og funksjonønsker på GitHub saksporeren: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Du kan rapportere feil, forbedringforslag og funksjonønsker på GitHub saksporeren: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Lisens</string>
     <string name="about_app_license">Dette programmet er lisensiert under GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Vis lisens</string>
-    <string name="about_app_icon_disclaimer_title">App ikon</string>
-    <string name="about_app_icon_disclaimer"><p>Orginalt ikon laget av <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> fra <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikoner</string>
-    <string name="about_icons_disclaimer"><p>Alle andre ikoner brukt av denne app\'en er <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Icons</a> laget av Google Inc. og lisensiert under Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Orginalt ikon laget av %1$s&lt;/p>&lt;p>Alle andre ikoner brukt av denne app\'en er &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons&lt;/a> laget av Google Inc. og lisensiert under Creative Commons License.&lt;/p></string>
     <string name="about_contribution_tab_title">Bidragsytere</string>
     <string name="about_license_tab_title">Lisens</string>
 
     <string name="widget_all_notes_title">Alle notater</string>
     <string name="widget_single_note_title">Enkeltnotat</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d valgt</item>
+        <item quantity="other">%d valgte</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-nl/plurals.xml
+++ b/app/src/main/res/values-nl/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d geselecteerd</item>
-        <item quantity="other">%d geselecteerd</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Versie</string>
-    <string name="about_version">Je gebruikt nu <strong>%1$s</strong></string>
+    <string name="about_version">Je gebruikt nu &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Beheerder</string>
     <string name="about_developers_title">Ontwikkelaar</string>
     <string name="about_translators_title">Vertalers</string>
-    <string name="about_translators">pejakm (Servisch), ageru (Français (Frans)), proninyaroslav (Russisch), mist (Tsjechisch)</string>
     <string name="about_testers_title">Testers</string>
     <string name="about_source_title">Broncode</string>
-    <string name="about_source">Dit is een GitHub project: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Dit is een GitHub project: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Kwesties</string>
-    <string name="about_issues">Je kan een bug, wijzigingen of functie verzoek melden bij de GitHub issue tracker: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Je kan een bug, wijzigingen of functie verzoek melden bij de GitHub issue tracker: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">App licentie</string>
     <string name="about_app_license">Deze applicatie valt onder de GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Licentie weergeven</string>
-    <string name="about_app_icon_disclaimer_title">App pictogram</string>
-    <string name="about_app_icon_disclaimer"><p>Het originele pictogram is gemaakt door <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> van <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">pictogram</string>
-    <string name="about_icons_disclaimer"><p>Alle pictogram\'s gebruikt door deze app zijn <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Materiaal ontwerp pictogram\'s</a> gemaakt door Google Inc. en vallen onder de Creatieve Content Licentie.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Het originele pictogram is gemaakt door %1$s&lt;/p>&lt;p>Alle pictogram\'s gebruikt door deze app zijn &lt;a href="https://materialdesignicons.com/" title="Link to Website">Materiaal ontwerp pictogram\'s&lt;/a> gemaakt door Google Inc. en vallen onder de Creatieve Content Licentie.&lt;/p></string>
     <string name="about_credits_tab_title">Credits</string>
     <string name="about_contribution_tab_title">Bijdrage</string>
     <string name="about_license_tab_title">Licentie</string>
 
     <string name="widget_all_notes_title">Alle notities</string>
     <string name="widget_single_note_title">Enkele notitie</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d geselecteerd</item>
+        <item quantity="other">%d geselecteerd</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-pl/plurals.xml
+++ b/app/src/main/res/values-pl/plurals.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d zaznaczone</item>
-        <item quantity="few">%d zaznaczonych</item>
-        <item quantity="other">%d zaznaczonych</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -67,28 +67,32 @@
 
     <!-- About -->
     <string name="about_version_title">Wersja</string>
-    <string name="about_version">Aktualnie używasz <strong>%1$s</strong></string>
+    <string name="about_version">Aktualnie używasz &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Opiekun</string>
     <string name="about_developers_title">Deweloperzy</string>
     <string name="about_translators_title">Tłumacze</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testerzy</string>
     <string name="about_source_title">Kod źródłowy</string>
-    <string name="about_source">Ten projekt jest hostowany na GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Ten projekt jest hostowany na GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Problemy</string>
-    <string name="about_issues">Możesz zgłaszać błędy, propozycje rozbudowy lub prośby o nowe funkcjonalności na GitHubie: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Możesz zgłaszać błędy, propozycje rozbudowy lub prośby o nowe funkcjonalności na GitHubie: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licencja aplikacji</string>
     <string name="about_app_license">Aplikacja jest chroniona licencją GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Zobacz licencję</string>
-    <string name="about_app_icon_disclaimer_title">Ikona aplikacji</string>
-    <string name="about_app_icon_disclaimer"><p>Oryginalna ikona została wykonana przez <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jana C. Borchardta</a> z <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikony</string>
-    <string name="about_icons_disclaimer"><p>Pozostałe ikony użyte w aplikacji są <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Ikonami Material Design</a> wykonanymi przez Google Inc. i są chronione licencją Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Oryginalna ikona została wykonana przez %1$s&lt;/p>&lt;p>Pozostałe ikony użyte w aplikacji są &lt;a href="https://materialdesignicons.com/" title="Link to Website">Ikonami Material Design&lt;/a> wykonanymi przez Google Inc. i są chronione licencją Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">O</string>
     <string name="about_contribution_tab_title">Wkład</string>
     <string name="about_license_tab_title">Licencja</string>
 
     <string name="widget_all_notes_title">Wszystkie notatki</string>
     <string name="widget_single_note_title">Pojedyncza notatka</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d zaznaczone</item>
+        <item quantity="few">%d zaznaczonych</item>
+        <item quantity="other">%d zaznaczonych</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-pt-rBR/plurals.xml
+++ b/app/src/main/res/values-pt-rBR/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d selecionados</item>
-        <item quantity="other">%d selecionado</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Versão</string>
-    <string name="about_version">Você está usando <strong>%1$s</strong></string>
+    <string name="about_version">Você está usando &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Mantenedor</string>
     <string name="about_developers_title">Desenvolvedores</string>
     <string name="about_translators_title">Tradutores </string>
-    <string name="about_translators">pejakm (Serbe), ageru (Francês (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testadores</string>
     <string name="about_source_title">Código fonte</string>
-    <string name="about_source">Este projeto está hospedado no GitHub:<a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Este projeto está hospedado no GitHub:&lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Problemas</string>
-    <string name="about_issues">Você pode relatar bugs, propostas de aprimoramento e solicitações de recursos no rastreador de problemas do GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Você pode relatar bugs, propostas de aprimoramento e solicitações de recursos no rastreador de problemas do GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licença de aplicativo</string>
     <string name="about_app_license">Esta aplicação está licenciada sob a GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Ver licença</string>
-    <string name="about_app_icon_disclaimer_title">Ícone do aplicativo</string>
-    <string name="about_app_icon_disclaimer"><p>Ícone original feito por<a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> da <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ícones</string>
-    <string name="about_icons_disclaimer"><p>Todos os outros ícones usados por este aplicativo são <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Material Design Icons</a>Feita pela Google Inc. e licenciada sob uma licença Creative Commons.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Ícone original feito por%1$s&lt;/p>&lt;p>Todos os outros ícones usados por este aplicativo são &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons&lt;/a>Feita pela Google Inc. e licenciada sob uma licença Creative Commons.&lt;/p></string>
     <string name="about_credits_tab_title">Créditos</string>
     <string name="about_contribution_tab_title">Contribuição</string>
     <string name="about_license_tab_title">Licença</string>
 
     <string name="widget_all_notes_title">Todas as notas</string>
     <string name="widget_single_note_title">Nota simples</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d selecionados</item>
+        <item quantity="other">%d selecionado</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-pt-rPT/plurals.xml
+++ b/app/src/main/res/values-pt-rPT/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d selecionado</item>
-        <item quantity="other">%d selecionados</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -55,28 +55,31 @@
 
     <!-- About -->
     <string name="about_version_title">Versão</string>
-    <string name="about_version">Está atualmente a usar a versão <strong>%1$s</strong></string>
+    <string name="about_version">Está atualmente a usar a versão &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Mantenedor</string>
     <string name="about_developers_title">Desenvolvedores</string>
     <string name="about_translators_title">Tradutores</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian)</string>
     <string name="about_testers_title">Experimentadores</string>
     <string name="about_source_title">Código fonte</string>
-    <string name="about_source">Este projeto está alojado no GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Este projeto está alojado no GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Problemas</string>
-    <string name="about_issues">Pode reportar erros, propor melhorias e pedir funcionalidades no seguidor de problemas do GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Pode reportar erros, propor melhorias e pedir funcionalidades no seguidor de problemas do GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Licença da aplicação</string>
     <string name="about_app_license">Esta aplicação está licenciada sob a licença GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Ver licença</string>
-    <string name="about_app_icon_disclaimer_title">Ícone da aplicação</string>
-    <string name="about_app_icon_disclaimer"><p>Ícone original criado por <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> de <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ícones</string>
-    <string name="about_icons_disclaimer"><p>Todos os restantes ícones usados por esta aplicação são <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> criados por Google Inc. e licenciados sob uma licença Creative Commons.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Ícone original criado por %1$s&lt;/p>&lt;p>Todos os restantes ícones usados por esta aplicação são &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons&lt;/a> criados por Google Inc. e licenciados sob uma licença Creative Commons.&lt;/p></string>
     <string name="about_credits_tab_title">Créditos</string>
     <string name="about_contribution_tab_title">Contribuição</string>
     <string name="about_license_tab_title">Licença</string>
 
     <string name="widget_all_notes_title">Todas as notas</string>
     <string name="widget_single_note_title">Nota única</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d selecionado</item>
+        <item quantity="other">%d selecionados</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ru/plurals.xml
+++ b/app/src/main/res/values-ru/plurals.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d выбрана</item>
-        <item quantity="few">%d выбрано</item>
-        <item quantity="many">%d выбрано</item>
-        <item quantity="other">%d выбрано</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -67,28 +67,33 @@
 
     <!-- About -->
     <string name="about_version_title">Версия</string>
-    <string name="about_version">Вы используете <strong>%1$s</strong></string>
+    <string name="about_version">Вы используете &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Сопровождающий</string>
     <string name="about_developers_title">Разработчики</string>
     <string name="about_translators_title">Переводчики</string>
-    <string name="about_translators">pejakm (Сербский), ageru (Французский), proninyaroslav (Русский), mist (Чешский)</string>
     <string name="about_testers_title">Тестеры</string>
     <string name="about_source_title">Исходный код</string>
-    <string name="about_source">Проект размещён на GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Проект размещён на GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Тикеты</string>
-    <string name="about_issues">Вы можете сообщать об ошибках, предложениях об улучшении и пожеланиях в систему тикетов GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Вы можете сообщать об ошибках, предложениях об улучшении и пожеланиях в систему тикетов GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Лицензия программы</string>
     <string name="about_app_license">Программа выпускается под лицензией GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Посмотреть лицензию</string>
-    <string name="about_app_icon_disclaimer_title">Значок программы</string>
-    <string name="about_app_icon_disclaimer"><p>Первоначальный логотип был сделан <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> на <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Значки</string>
-    <string name="about_icons_disclaimer"><p>Все дальнейшие значки, которые используются в этой программе, являются <a href="https://materialdesignicons.com/" title="Link to Website">Material Design значки</a> от Google Inc. и лицензированны под Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Первоначальный логотип был сделан %1$s&lt;/p>&lt;p>Все дальнейшие значки, которые используются в этой программе, являются &lt;a href="https://materialdesignicons.com/" title="Link to Website">Material Design значки&lt;/a> от Google Inc. и лицензированны под Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">Заслуги</string>
     <string name="about_contribution_tab_title">Учавствовать</string>
     <string name="about_license_tab_title">Лицензия</string>
 
     <string name="widget_all_notes_title">Все заметки</string>
     <string name="widget_single_note_title">Одна заметка</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d выбрана</item>
+        <item quantity="few">%d выбрано</item>
+        <item quantity="many">%d выбрано</item>
+        <item quantity="other">%d выбрано</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -66,7 +66,7 @@
 
     <!-- About -->
     <string name="about_version_title">Verzia</string>
-    <string name="about_version">Momentálne používate <strong>%1$s</strong></string>
+    <string name="about_version">Momentálne používate &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Udržovateľ</string>
     <string name="about_developers_title">Vývojári</string>
     <string name="about_translators_title">Prekladatelia</string>
@@ -75,7 +75,6 @@
     <string name="about_issues_title">Problémy</string>
     <string name="about_app_license_title">Licencia aplikácie</string>
     <string name="about_app_license_button">Zobraziť licenciu</string>
-    <string name="about_app_icon_disclaimer_title">Ikona aplikácie</string>
     <string name="about_icons_disclaimer_title">Ikony</string>
     <string name="about_contribution_tab_title">Príspevok</string>
     <string name="about_license_tab_title">Licencia</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals -->
     <plurals name="ab_selected">
         <item quantity="one">%d izbran(a)</item>
         <item quantity="two">%d izbrana(i)</item>

--- a/app/src/main/res/values-sq/plurals.xml
+++ b/app/src/main/res/values-sq/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d të përzgjedhura</item>
-        <item quantity="other">%d të përzgjedhura</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -67,28 +67,31 @@
 
     <!-- About -->
     <string name="about_version_title">Versioni</string>
-    <string name="about_version">Për momentin ju po përdorni <strong>%1$s</strong></string>
+    <string name="about_version">Për momentin ju po përdorni &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Mirëmbajtësi</string>
     <string name="about_developers_title">Zhvilluesit</string>
     <string name="about_translators_title">Përkthyesit</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testuesit</string>
     <string name="about_source_title">Kodi burim</string>
-    <string name="about_source">Ky projekt ruhet në GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Ky projekt ruhet në GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Çështjet</string>
-    <string name="about_issues">Ju mund të raportoni buge, përmirësoni propozimet dhe të paraqisni propozime në gjurmuesin e çështjeve të GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Ju mund të raportoni buge, përmirësoni propozimet dhe të paraqisni propozime në gjurmuesin e çështjeve të GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Liçensa e aplikacionit</string>
     <string name="about_app_license">Ky aplikacion është liçensuar nën GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">Trego liçensën</string>
-    <string name="about_app_icon_disclaimer_title">Ikona e aplikacionit</string>
-    <string name="about_app_icon_disclaimer"><p>Ikona origjinale u bë nga <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> nga <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Ikonat</string>
-    <string name="about_icons_disclaimer"><p>Të gjitha ikonat vijuese të përdorura nga ky aplikacion janë <a href=\"https://materialdesignicons.com/\" title=\"Link to Website\">Ikona Material Design </a> të bëra nga Google Inc. dhe të liçensuara nën Liçensën Creative Commons.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Ikona origjinale u bë nga %1$s&lt;/p>&lt;p>Të gjitha ikonat vijuese të përdorura nga ky aplikacion janë &lt;a href="https://materialdesignicons.com/" title="Link to Website">Ikona Material Design &lt;/a> të bëra nga Google Inc. dhe të liçensuara nën Liçensën Creative Commons.&lt;/p></string>
     <string name="about_credits_tab_title">Kreditet</string>
     <string name="about_contribution_tab_title">Kontributi</string>
     <string name="about_license_tab_title">Liçensë</string>
 
     <string name="widget_all_notes_title">Të gjitha shënimet</string>
     <string name="widget_single_note_title">Një shënim i vetëm</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d të përzgjedhura</item>
+        <item quantity="other">%d të përzgjedhura</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-sr/plurals.xml
+++ b/app/src/main/res/values-sr/plurals.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d изабрана</item>
-        <item quantity="few">%d изабрана</item>
-        <item quantity="other">%d изабрана</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -54,26 +54,30 @@
 
     <!-- About -->
     <string name="about_version_title">Издање</string>
-    <string name="about_version">Текуће издање је <strong>%1$s</strong></string>
+    <string name="about_version">Текуће издање је &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Главни програмер</string>
     <string name="about_developers_title">Програмери</string>
     <string name="about_translators_title">Преводиоци</string>
-    <string name="about_translators">Младен Пејаковић (српски), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Тестери</string>
     <string name="about_source_title">Изворни кôд</string>
-    <string name="about_source">Пројекат је хостован на Гитхабу: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">Пројекат је хостован на Гитхабу: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Грешке</string>
-    <string name="about_issues">Пријаве грешака, предлоге и захтеве можете да оставите на Гитхабовом пратиоцу пријава: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">Пријаве грешака, предлоге и захтеве можете да оставите на Гитхабовом пратиоцу пријава: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">Лиценца апликације</string>
     <string name="about_app_license">Ова апликација је лиценцирана под ГНУовом Општом јавном лиценцом (ГПЛ) в3+.</string>
     <string name="about_app_license_button">Прикажи лиценцу</string>
-    <string name="about_app_icon_disclaimer_title">Икона апликације</string>
-    <string name="about_app_icon_disclaimer"><p>Изворни аутор <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> са <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
     <string name="about_icons_disclaimer_title">Иконе</string>
-    <string name="about_icons_disclaimer"><p>Све остале иконе ове апликације су <a href="https://materialdesignicons.com/" title="веза на вебсајт">иконе материјал дизајна</a> које је креирао Google Inc. и лиценциране су Creative Commons лиценцом.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Изворни аутор %1$s&lt;/p>&lt;p>Све остале иконе ове апликације су &lt;a href="https://materialdesignicons.com/" title="веза на вебсајт">иконе материјал дизајна&lt;/a> које је креирао Google Inc. и лиценциране су Creative Commons лиценцом.&lt;/p></string>
     <string name="about_credits_tab_title">Заслуге</string>
     <string name="about_contribution_tab_title">Допринос</string>
     <string name="about_license_tab_title">Лиценца</string>
 
-    </resources>
+    
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d изабрана</item>
+        <item quantity="few">%d изабрана</item>
+        <item quantity="other">%d изабрана</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Plurals -->
     <plurals name="ab_selected">
         <item quantity="one">%d vald</item>
         <item quantity="other">%d valda</item>

--- a/app/src/main/res/values-zh-rCN/plurals.xml
+++ b/app/src/main/res/values-zh-rCN/plurals.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="other">%d 已选择</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -67,28 +67,30 @@
 
     <!-- About -->
     <string name="about_version_title">版本</string>
-    <string name="about_version">你正在使用<strong>%1$s</strong></string>
+    <string name="about_version">你正在使用&lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">维护者</string>
     <string name="about_developers_title">开发者</string>
     <string name="about_translators_title">翻译人员</string>
-    <string name="about_translators">pejakm (塞尔维亚语), ageru (Français (法语)), proninyaroslav (俄语), mist (捷克语)</string>
     <string name="about_testers_title">测试人员</string>
     <string name="about_source_title">源代码</string>
-    <string name="about_source">本项目托管在GitHub: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/\">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">本项目托管在GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">问题</string>
-    <string name="about_issues">你可以报告缺陷, 优化建议和特性要求在 GitHub 发布管理器: <a href=\"https://github.com/stefan-niedermann/OwnCloud-Notes/issues\">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">你可以报告缺陷, 优化建议和特性要求在 GitHub 发布管理器: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">应用授权</string>
     <string name="about_app_license">此程序通过GNU通用公共许可证V3+授权。</string>
     <string name="about_app_license_button">查看授权</string>
-    <string name="about_app_icon_disclaimer_title">应用图标</string>
-    <string name="about_app_icon_disclaimer"><p>原始图标由 <a href=\"http://jancborchardt.net/\" title=\"Jan C. Borchardt\">Jan C. Borchardt</a> 在 <a href=\"https://github.com/owncloud/notes/commits/master/img/notes.svg\" title=\"GitHub\">www.github.com</a> 创作的</p></string>
     <string name="about_icons_disclaimer_title">图标</string>
-    <string name="about_icons_disclaimer"><p>这个应用程序使用的所有更多的图标 <a href=\"https://materialdesignicons.com/\" title=\"链接站点\">材料设计图标</a> 由谷歌公司推出. 在知识共享协议下授权.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>原始图标由 %1$s 创作的&lt;/p>&lt;p>这个应用程序使用的所有更多的图标 &lt;a href="https://materialdesignicons.com/" title="链接站点">材料设计图标&lt;/a> 由谷歌公司推出. 在知识共享协议下授权.&lt;/p></string>
     <string name="about_credits_tab_title">致谢</string>
     <string name="about_contribution_tab_title">贡献</string>
     <string name="about_license_tab_title">授权</string>
 
     <string name="widget_all_notes_title">所有便笺</string>
     <string name="widget_single_note_title">单个便笺</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="other">%d 已选择</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <plurals name="ab_selected">
-        <item quantity="one">%d selected</item>
-        <item quantity="other">%d selected</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,34 +64,46 @@
     <!-- Snackbar Actions -->
     <string name="snackbar_settings">Settings</string>
 
+    <!-- URLs -->
+    <string name="url_source" translatable="false">https://github.com/stefan-niedermann/nextcloud-notes</string>
+    <string name="url_issues" translatable="false">https://github.com/stefan-niedermann/nextcloud-notes/issues</string>
+    <string name="url_license" translatable="false">https://github.com/stefan-niedermann/nextcloud-notes/blob/master/LICENSE</string>
+    <string name="url_translations" translatable="false">https://www.transifex.com/nextcloud/nextcloud/</string>
 
     <!-- About -->
     <string name="about_version_title">Version</string>
-    <string name="about_version">You are currently using <strong>%1$s</strong></string>
+    <string name="about_version">You are currently using &lt;strong>%1$s&lt;/strong></string>
     <string name="about_maintainer_title">Maintainer</string>
-    <string name="about_maintainer" translatable="false"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
+    <string name="about_maintainer" translatable="false">&lt;a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen&lt;/a></string>
     <string name="about_developers_title">Developers</string>
     <string name="about_developers" translatable="false">Stefan Niedermann, Kristof Hamann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Translators</string>
-    <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
+    <string name="about_translators_transifex">Nextcloud community on &lt;a href="%1$s">Transifex&lt;/a></string>
     <string name="about_testers_title">Testers</string>
     <string name="about_testers" translatable="false">Jan C. Borchardt</string>
     <string name="about_source_title">Source code</string>
-    <string name="about_source">This project is hosted on GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
+    <string name="about_source">This project is hosted on GitHub: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_issues_title">Issues</string>
-    <string name="about_issues">You can report bugs, enhancement proposals and feature requests at the GitHub issue tracker: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
+    <string name="about_issues">You can report bugs, enhancement proposals and feature requests at the GitHub issue tracker: &lt;a href="%1$s">%1$s&lt;/a></string>
+    <string name="about_translate_title">Translate</string>
+    <string name="about_translate">Join the Nextcloud team on Transifex and help us to translate this app: &lt;a href="%1$s">%1$s&lt;/a></string>
     <string name="about_app_license_title">App license</string>
     <string name="about_app_license">This application is licensed under the GNU GENERAL PUBLIC LICENSE v3+.</string>
     <string name="about_app_license_button">View license</string>
-    <string name="about_app_icon_disclaimer_title">App icon</string>
-    <string name="about_app_icon_disclaimer"><p>Original icon made by <a href="http://jancborchardt.net/" title="Jan C. Borchardt">Jan C. Borchardt</a> from <a href="https://github.com/owncloud/notes/commits/master/img/notes.svg" title="GitHub">www.github.com</a></p></string>
+    <string name="about_app_icon_author" translatable="false">&lt;a href="http://jancborchardt.net/">Jan C. Borchardt&lt;/a> (&lt;a href="https://github.com/owncloud/notes/commits/master/img/notes.svg">GitHub&lt;/a>)</string>
     <string name="about_icons_disclaimer_title">Icons</string>
-    <string name="about_icons_disclaimer"><p>All further icons used by this app are <a href="https://materialdesignicons.com/" title="Link to Website">Material Design Icons</a> made by Google Inc. and licensed under a Creative Commons License.</p></string>
-
+    <string name="about_icons_disclaimer">&lt;p>Original icon made by %1$s&lt;/p>&lt;p>All further icons used by this app are &lt;a href="https://materialdesignicons.com/">Material Design Icons&lt;/a> made by Google Inc. and licensed under a Creative Commons License.&lt;/p></string>
     <string name="about_credits_tab_title">Credits</string>
     <string name="about_contribution_tab_title">Contribution</string>
     <string name="about_license_tab_title">License</string>
 
     <string name="widget_all_notes_title">All notes</string>
     <string name="widget_single_note_title">Single note</string>
+
+
+    <!-- Plurals -->
+    <plurals name="ab_selected">
+        <item quantity="one">%d selected</item>
+        <item quantity="other">%d selected</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
This will fix #175. See there for more details.

Since this have to be commited before @nextcloud-bot exports new translations from transifex in the next night, I will merge this in this evening at the latest. If someone wants to review this, please be quick :wink: 

One note: Now, the `<` are escaped by `&lt;` in the string resources. Therefore, we have to use `Html.fromHtml(String)` which is replaced by `Html.fromHtml(String, int)` in API 24. For better readability, I have introduced a helper class which takes care of this distinction.