### PR TITLE
speed-up synchronization and introduce categories

### DIFF
--- a/app/src/androidTest/java/it/niedermann/owncloud/notes/model/NoteTest.java
+++ b/app/src/androidTest/java/it/niedermann/owncloud/notes/model/NoteTest.java
@@ -11,7 +11,7 @@ import java.util.Calendar;
 public class NoteTest extends TestCase {
 
     public void testMarkDownStrip() {
-        CloudNote note = new CloudNote(0, Calendar.getInstance(), "#Title", "", false);
+        CloudNote note = new CloudNote(0, Calendar.getInstance(), "#Title", "", false, null, null);
         assertTrue("Title".equals(note.getTitle()));
         note.setTitle("* Aufzählung");
         assertTrue("Aufzählung".equals(note.getTitle()));

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/CreateNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/CreateNoteActivity.java
@@ -72,7 +72,7 @@ public class CreateNoteActivity extends AppCompatActivity {
             case R.id.action_create_save:
                 editTextField.setEnabled(false);
                 String content = editTextField.getText().toString();
-                NoteSQLiteOpenHelper db = new NoteSQLiteOpenHelper(this);
+                NoteSQLiteOpenHelper db = NoteSQLiteOpenHelper.getInstance(this);
                 Intent data = new Intent();
                 data.putExtra(NotesListViewActivity.CREATED_NOTE, db.getNote(db.addNoteAndSync(content)));
                 setResult(RESULT_OK, data);

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
@@ -83,7 +83,7 @@ public class EditNoteActivity extends AppCompatActivity {
                     }
                 });
 
-        db = new NoteSQLiteOpenHelper(this);
+        db = NoteSQLiteOpenHelper.getInstance(this);
         actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setTitle(note.getTitle());

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -82,7 +82,7 @@ public class NotesListViewActivity extends AppCompatActivity implements
         setContentView(R.layout.activity_notes_list_view);
 
         // Display Data
-        db = new NoteSQLiteOpenHelper(this);
+        db = NoteSQLiteOpenHelper.getInstance(this);
         initList();
         refreshList();
 
@@ -417,7 +417,7 @@ public class NotesListViewActivity extends AppCompatActivity implements
             }
         } else if (requestCode == server_settings) {
             // Create new Instance with new URL and credentials
-            db = new NoteSQLiteOpenHelper(this);
+            db = NoteSQLiteOpenHelper.getInstance(this);
             if(db.getNoteServerSyncHelper().isSyncPossible()) {
                 adapter.removeAll();
                 swipeRefreshLayout.setRefreshing(true);
@@ -468,7 +468,7 @@ public class NotesListViewActivity extends AppCompatActivity implements
     @Override
     public void onNoteFavoriteClick(int position, View view) {
         DBNote note = (DBNote) adapter.getItem(position);
-        NoteSQLiteOpenHelper db = new NoteSQLiteOpenHelper(view.getContext());
+        NoteSQLiteOpenHelper db = NoteSQLiteOpenHelper.getInstance(view.getContext());
         db.toggleFavorite(note, syncCallBack);
         adapter.notifyItemChanged(position);
         refreshList();

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SelectSingleNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SelectSingleNoteActivity.java
@@ -37,7 +37,7 @@ public class SelectSingleNoteActivity extends AppCompatActivity implements ItemA
         setResult(RESULT_CANCELED);
         setContentView(R.layout.activity_select_single_note);
         // Display Data
-        db = new NoteSQLiteOpenHelper(this);
+        db = NoteSQLiteOpenHelper.getInstance(this);
         db.getNoteServerSyncHelper().scheduleSync(false);
         setListView(db.getNotes());
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/widget/AllNotesWidget.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/widget/AllNotesWidget.java
@@ -60,14 +60,14 @@ public class AllNotesWidget extends AppWidgetProvider {
             mContext = context;
             mAppWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID,
                     AppWidgetManager.INVALID_APPWIDGET_ID);
-            NoteSQLiteOpenHelper db = new NoteSQLiteOpenHelper(mContext);
+            NoteSQLiteOpenHelper db = NoteSQLiteOpenHelper.getInstance(mContext);
             db.getNoteServerSyncHelper().scheduleSync(false);
             mWidgetItems = db.getNotes();
-            mWidgetItems.add(new DBNote(0, 0, Calendar.getInstance(), "Test-Titel", "Test-Beschreibung", false, DBStatus.VOID));
+            mWidgetItems.add(new DBNote(0, 0, Calendar.getInstance(), "Test-Titel", "Test-Beschreibung", false, null, null, DBStatus.VOID));
         }
 
         public void onCreate() {
-            mWidgetItems.add(new DBNote(0, 0, Calendar.getInstance(), "Test-Titel", "Test-Beschreibung", false, DBStatus.VOID));
+            mWidgetItems.add(new DBNote(0, 0, Calendar.getInstance(), "Test-Titel", "Test-Beschreibung", false, null, null, DBStatus.VOID));
         }
 
         @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/CloudNote.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/CloudNote.java
@@ -18,14 +18,18 @@ public class CloudNote implements Serializable {
     private Calendar modified = null;
     private String content = "";
     private boolean favorite = false;
+    private String category = "";
+    private String etag = "";
 
-    public CloudNote(long remoteId, Calendar modified, String title, String content, boolean favorite) {
+    public CloudNote(long remoteId, Calendar modified, String title, String content, boolean favorite, String category, String etag) {
         this.remoteId = remoteId;
         if (title != null)
             setTitle(title);
         setTitle(title);
         setContent(content);
         setFavorite(favorite);
+        setCategory(category);
+        setEtag(etag);
         this.modified = modified;
     }
 
@@ -51,8 +55,9 @@ public class CloudNote implements Serializable {
     }
 
     public String getModified(String format) {
-        return new SimpleDateFormat(format, Locale.GERMANY)
-                .format(this.getModified().getTimeInMillis());
+        if(modified==null)
+            return null;
+        return new SimpleDateFormat(format, Locale.GERMANY) .format(this.getModified().getTimeInMillis());
     }
 
     public void setModified(Calendar modified) {
@@ -75,8 +80,24 @@ public class CloudNote implements Serializable {
         this.favorite = favorite;
     }
 
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category==null ? "" : category;
+    }
+
     @Override
     public String toString() {
-        return "#" + getRemoteId() + " " + (isFavorite() ? " (*) " : "     ") + getTitle() + " (" + getModified(NoteSQLiteOpenHelper.DATE_FORMAT) + ")";
+        return "R" + getRemoteId() + " " + (isFavorite() ? " (*) " : "     ") + getCategory() + " / " + getTitle() + " (" + getModified(NoteSQLiteOpenHelper.DATE_FORMAT) + " / " + getEtag() + ")";
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/DBNote.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/DBNote.java
@@ -3,7 +3,6 @@ package it.niedermann.owncloud.notes.model;
 import java.io.Serializable;
 import java.util.Calendar;
 
-import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
 import it.niedermann.owncloud.notes.util.NoteUtil;
 
 /**
@@ -16,8 +15,8 @@ public class DBNote extends CloudNote implements Item, Serializable {
     private DBStatus status;
     private String excerpt = "";
 
-    public DBNote(long id, long remoteId, Calendar modified, String title, String content, boolean favorite, DBStatus status) {
-        super(remoteId, modified, title, content, favorite);
+    public DBNote(long id, long remoteId, Calendar modified, String title, String content, boolean favorite, String category, String etag, DBStatus status) {
+        super(remoteId, modified, title, content, favorite, category, etag);
         this.id = id;
         setExcerpt(content);
         this.status = status;
@@ -55,6 +54,6 @@ public class DBNote extends CloudNote implements Item, Serializable {
 
     @Override
     public String toString() {
-        return "#" + getId() + "/R"+getRemoteId()+" " + (isFavorite() ? " (*) " : "     ") + getTitle() + " (" + getModified(NoteSQLiteOpenHelper.DATE_FORMAT) + ") " + getStatus();
+        return "#"+getId()+"/" + super.toString() + " " + getStatus();
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/ItemAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/ItemAdapter.java
@@ -91,6 +91,8 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             final DBNote note = (DBNote) item;
             final NoteViewHolder nvHolder = ((NoteViewHolder) holder);
             nvHolder.noteTitle.setText(note.getTitle());
+            nvHolder.noteCategory.setVisibility(note.getCategory().isEmpty() ? View.GONE : View.VISIBLE);
+            nvHolder.noteCategory.setText(note.getCategory());
             nvHolder.noteExcerpt.setText(note.getExcerpt());
             nvHolder.noteStatus.setVisibility(DBStatus.VOID.equals(note.getStatus()) ? View.GONE : View.VISIBLE);
             nvHolder.noteFavorite.setImageResource(note.isFavorite() ? R.drawable.ic_star_grey600_24dp : R.drawable.ic_star_outline_grey600_24dp);
@@ -156,6 +158,7 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public class NoteViewHolder extends RecyclerView.ViewHolder implements View.OnLongClickListener, View.OnClickListener {
         // each data item is just a string in this case
         public TextView noteTitle;
+        public TextView noteCategory;
         public TextView noteExcerpt;
         public ImageView noteStatus;
         public ImageView noteFavorite;
@@ -164,6 +167,7 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         private NoteViewHolder(View v) {
             super(v);
             this.noteTitle = (TextView) v.findViewById(R.id.noteTitle);
+            this.noteCategory = (TextView) v.findViewById(R.id.noteCategory);
             this.noteExcerpt = (TextView) v.findViewById(R.id.noteExcerpt);
             this.noteStatus = (ImageView) v.findViewById(R.id.noteStatus);
             this.noteFavorite = (ImageView) v.findViewById(R.id.noteFavorite);

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
@@ -11,8 +11,10 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import it.niedermann.owncloud.notes.model.DBNote;
 import it.niedermann.owncloud.notes.model.DBStatus;
@@ -26,9 +28,10 @@ import it.niedermann.owncloud.notes.util.NoteUtil;
  * Created by stefan on 19.09.15.
  */
 public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
+
     public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
-    private static final int database_version = 6;
+    private static final int database_version = 7;
     private static final String database_name = "OWNCLOUD_NOTES";
     private static final String table_notes = "NOTES";
     private static final String key_id = "ID";
@@ -38,16 +41,28 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
     private static final String key_modified = "MODIFIED";
     private static final String key_content = "CONTENT";
     private static final String key_favorite = "FAVORITE";
-    private static final String[] columns = {key_id, key_remote_id, key_status, key_title, key_modified, key_content, key_favorite};
+    private static final String key_category = "CATEGORY";
+    private static final String key_etag = "ETAG";
+    private static final String[] columns = {key_id, key_remote_id, key_status, key_title, key_modified, key_content, key_favorite, key_category, key_etag };
     private static final String default_order = key_favorite + " DESC, " + key_modified + " DESC";
+
+    private static NoteSQLiteOpenHelper instance;
 
     private NoteServerSyncHelper serverSyncHelper = null;
     private Context context = null;
 
-    public NoteSQLiteOpenHelper(Context context) {
+    private NoteSQLiteOpenHelper(Context context) {
         super(context, database_name, null, database_version);
         this.context = context.getApplicationContext();
         serverSyncHelper = NoteServerSyncHelper.getInstance(this);
+        //recreateDatabase(getWritableDatabase());
+    }
+
+    public static NoteSQLiteOpenHelper getInstance(Context context) {
+        if(instance==null)
+            return instance = new NoteSQLiteOpenHelper(context.getApplicationContext());
+        else
+            return instance;
     }
 
     public NoteServerSyncHelper getNoteServerSyncHelper() {
@@ -61,19 +76,24 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      */
     @Override
     public void onCreate(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE '" + table_notes + "' ( '" +
-                key_id + "' INTEGER PRIMARY KEY AUTOINCREMENT, '" +
-                key_remote_id + "' INTEGER, '" +
-                key_status + "' VARCHAR(50), '" +
-                key_title + "' TEXT, '" +
-                key_modified + "' TEXT, '" +
-                key_content + "' TEXT, '" +
-                key_favorite + "' INTEGER DEFAULT 0)");
-        // FIXME create index for status and remote_id
+        db.execSQL("CREATE TABLE " + table_notes + " ( " +
+                key_id + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                key_remote_id + " INTEGER, " +
+                key_status + " VARCHAR(50), " +
+                key_title + " TEXT, " +
+                key_modified + " TEXT, " +
+                key_content + " TEXT, " +
+                key_favorite + " INTEGER DEFAULT 0, " +
+                key_category + " TEXT NOT NULL DEFAULT '', " +
+                key_etag + " TEXT)");
+        createIndexes(db);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        if(oldVersion<3) {
+            recreateDatabase(db);
+        }
         if(oldVersion<4) {
             clearDatabase(db);
         }
@@ -85,10 +105,42 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         if(oldVersion<6) {
             db.execSQL("ALTER TABLE "+table_notes+" ADD COLUMN "+key_favorite+" INTEGER DEFAULT 0");
         }
+        if(oldVersion<7) {
+            dropIndexes(db);
+            db.execSQL("ALTER TABLE "+table_notes+" ADD COLUMN "+key_category+" TEXT NOT NULL DEFAULT ''");
+            db.execSQL("ALTER TABLE "+table_notes+" ADD COLUMN "+key_etag+" TEXT");
+            createIndexes(db);
+        }
     }
 
     private void clearDatabase(SQLiteDatabase db) {
         db.delete(table_notes, null, null);
+    }
+
+    private void recreateDatabase(SQLiteDatabase db) {
+        dropIndexes(db);
+        db.execSQL("DROP TABLE "+table_notes);
+        onCreate(db);
+    }
+
+    private void dropIndexes(SQLiteDatabase db) {
+        Cursor c = db.query("sqlite_master", new String[]{"name"}, "type=?", new String[]{"index"}, null, null, null);
+        while (c.moveToNext()) {
+            db.execSQL( "DROP INDEX "+c.getString(0));
+        }
+        c.close();
+    }
+
+    private void createIndexes(SQLiteDatabase db) {
+        createIndex(db, table_notes, key_remote_id);
+        createIndex(db, table_notes, key_status);
+        createIndex(db, table_notes, key_favorite);
+        createIndex(db, table_notes, key_category);
+        createIndex(db, table_notes, key_modified);
+    }
+    private void createIndex(SQLiteDatabase db, String table, String column) {
+        String indexName = table+"_"+column+"_idx";
+        db.execSQL("CREATE INDEX IF NOT EXISTS "+indexName+" ON "+table+"("+column+")");
     }
 
     public Context getContext() {
@@ -102,7 +154,7 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      */
     @SuppressWarnings("UnusedReturnValue")
     public long addNoteAndSync(String content) {
-        CloudNote note = new CloudNote(0, Calendar.getInstance(), NoteUtil.generateNoteTitle(content), content, false);
+        CloudNote note = new CloudNote(0, Calendar.getInstance(), NoteUtil.generateNoteTitle(content), content, false, null, null);
         return addNoteAndSync(note);
     }
 
@@ -113,7 +165,7 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      */
     @SuppressWarnings("UnusedReturnValue")
     public long addNoteAndSync(CloudNote note) {
-        DBNote dbNote =  new DBNote(0, 0, note.getModified(), note.getTitle(), note.getContent(), note.isFavorite(), DBStatus.LOCAL_EDITED);
+        DBNote dbNote =  new DBNote(0, 0, note.getModified(), note.getTitle(), note.getContent(), note.isFavorite(), note.getCategory(), note.getEtag(), DBStatus.LOCAL_EDITED);
         long id = addNote(dbNote);
         getNoteServerSyncHelper().scheduleSync(true);
         return id;
@@ -144,6 +196,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         values.put(key_modified, note.getModified(NoteSQLiteOpenHelper.DATE_FORMAT));
         values.put(key_content, note.getContent());
         values.put(key_favorite, note.isFavorite());
+        values.put(key_category, note.getCategory());
+        values.put(key_etag, note.getEtag());
         long id = db.insert(table_notes, null, values);
         db.close();
         return id;
@@ -157,23 +211,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      */
     @SuppressWarnings("unused")
     public DBNote getNote(long id) {
-        SQLiteDatabase db = this.getReadableDatabase();
-        Cursor cursor =
-                db.query(table_notes,
-                        columns,
-                        key_id + " = ? AND " + key_status + " != ?",
-                        new String[]{String.valueOf(id), DBStatus.LOCAL_DELETED.getTitle()},
-                        null,
-                        null,
-                        null,
-                        null);
-        if (cursor == null) {
-            return null;
-        }
-        cursor.moveToFirst();
-        DBNote note = getNoteFromCursor(cursor);
-        cursor.close();
-        return note;
+        List<DBNote> notes = getNotesCustom(key_id + " = ? AND " + key_status + " != ?", new String[]{String.valueOf(id), DBStatus.LOCAL_DELETED.getTitle()}, null);
+        return notes.isEmpty() ? null : notes.get(0);
     }
 
     /**
@@ -187,10 +226,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         SQLiteDatabase db = getReadableDatabase();
         Cursor cursor = db.query(table_notes, columns, selection, selectionArgs, null, null, orderBy);
         List<DBNote> notes = new ArrayList<>();
-        if (cursor.moveToFirst()) {
-            do {
-                notes.add(getNoteFromCursor(cursor));
-            } while (cursor.moveToNext());
+        while (cursor.moveToNext()) {
+            notes.add(getNoteFromCursor(cursor));
         }
         cursor.close();
         return notes;
@@ -210,15 +247,26 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         } catch (ParseException e) {
             e.printStackTrace();
         }
-        return new DBNote(cursor.getLong(0), cursor.getLong(1), modified, cursor.getString(3), cursor.getString(5), cursor.getInt(6)>0, DBStatus.parse(cursor.getString(2)));
+        return new DBNote(cursor.getLong(0), cursor.getLong(1), modified, cursor.getString(3), cursor.getString(5), cursor.getInt(6)>0, cursor.getString(7), cursor.getString(8), DBStatus.parse(cursor.getString(2)));
     }
 
     public void debugPrintFullDB() {
         List<DBNote> notes = getNotesCustom("", new String[]{}, default_order);
-        Log.d(getClass().getSimpleName(), "Full Database:");
+        Log.d(getClass().getSimpleName(), "Full Database ("+notes.size()+" notes):");
         for (DBNote note : notes) {
             Log.d(getClass().getSimpleName(), "     "+note);
         }
+    }
+
+    public Map<Long, Long> getIdMap() {
+        Map<Long, Long> result = new HashMap<>();
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.query(table_notes, new String[]{ key_remote_id, key_id }, key_status + " != ?", new String[]{DBStatus.LOCAL_DELETED.getTitle()}, null, null, null);
+        while(cursor.moveToNext()) {
+            result.put(cursor.getLong(0), cursor.getLong(1));
+        }
+        cursor.close();
+        return result;
     }
 
     /**
@@ -285,9 +333,9 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         debugPrintFullDB();
         DBNote newNote;
         if(newContent==null) {
-            newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), oldNote.getModified(), oldNote.getTitle(), oldNote.getContent(), oldNote.isFavorite(), DBStatus.LOCAL_EDITED);
+            newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), oldNote.getModified(), oldNote.getTitle(), oldNote.getContent(), oldNote.isFavorite(), oldNote.getCategory(), oldNote.getEtag(), DBStatus.LOCAL_EDITED);
         } else {
-            newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), Calendar.getInstance(), NoteUtil.generateNoteTitle(newContent), newContent, oldNote.isFavorite(), DBStatus.LOCAL_EDITED);
+            newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), Calendar.getInstance(), NoteUtil.generateNoteTitle(newContent), newContent, oldNote.isFavorite(), oldNote.getCategory(), oldNote.getEtag(), DBStatus.LOCAL_EDITED);
         }
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues values = new ContentValues();
@@ -339,6 +387,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         values.put(key_modified, remoteNote.getModified(DATE_FORMAT));
         values.put(key_content, remoteNote.getContent());
         values.put(key_favorite, remoteNote.isFavorite());
+        values.put(key_category, remoteNote.getCategory());
+        values.put(key_etag, remoteNote.getEtag());
         String whereClause;
         String[] whereArgs;
         if(forceUnchangedDBNoteState!=null) {
@@ -346,13 +396,13 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
             // update only, if not modified locally during the synchronization
             // (i.e. all (!) user changeable columns (content, favorite) should still have the same value),
             // uses reference value gathered at start of synchronization
-            whereClause = key_id + " = ? AND " + key_content + " = ? AND " + key_favorite + " = ?";
-            whereArgs = new String[]{String.valueOf(id), forceUnchangedDBNoteState.getContent(), forceUnchangedDBNoteState.isFavorite()?"1":"0"};
+            whereClause = key_id + " = ? AND " + key_content + " = ? AND " + key_favorite + " = ? AND " + key_category + " = ?";
+            whereArgs = new String[]{String.valueOf(id), forceUnchangedDBNoteState.getContent(), forceUnchangedDBNoteState.isFavorite()?"1":"0", forceUnchangedDBNoteState.getCategory()};
         } else {
             // used by: NoteServerSyncHelper.SyncTask.pullRemoteChanges()
             // update only, if not modified locally (i.e. STATUS="") and if modified remotely (i.e. any (!) column has changed)
-            whereClause = key_id + " = ? AND " + key_status + " = ? AND ("+key_modified+"!=? OR "+key_content+"!=? OR "+key_favorite+"!=?)";
-            whereArgs = new String[]{String.valueOf(id), DBStatus.VOID.getTitle(), remoteNote.getModified(DATE_FORMAT), remoteNote.getContent(), remoteNote.isFavorite()?"1":"0"};
+            whereClause = key_id + " = ? AND " + key_status + " = ? AND ("+key_modified+"!=? OR "+key_title+"!=? OR "+key_favorite+"!=? OR "+key_category+"!=? OR "+(remoteNote.getEtag()!=null ? key_etag+" IS NULL OR " : "")+key_etag+"!=? OR "+key_content+"!=?)";
+            whereArgs = new String[]{String.valueOf(id), DBStatus.VOID.getTitle(), remoteNote.getModified(DATE_FORMAT), remoteNote.getTitle(), remoteNote.isFavorite()?"1":"0", remoteNote.getCategory(), remoteNote.getEtag(), remoteNote.getContent()};
         }
         int i = db.update(table_notes, values, whereClause, whereArgs);
         db.close();

--- a/app/src/main/res/layout/fragment_notes_list_note_item.xml
+++ b/app/src/main/res/layout/fragment_notes_list_note_item.xml
@@ -23,16 +23,30 @@
         android:textSize="16sp" />
 
     <TextView
-        android:id="@+id/noteExcerpt"
-        android:layout_width="fill_parent"
+        android:id="@+id/noteCategory"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_marginStart="16dp"
         android:layout_marginLeft="16dp"
+        android:layout_below="@id/noteTitle"
+        android:maxLines="1"
+        android:textColor="@drawable/list_item_color_selector"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/noteExcerpt"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/noteCategory"
+        android:layout_toEndOf="@id/noteCategory"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_below="@id/noteTitle"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
-        android:layout_below="@id/noteTitle"
         android:ellipsize="end"
         android:maxLines="1"
         android:textColor="@drawable/list_item_color_selector_low"


### PR DESCRIPTION
Since #167 has to be reworked (see discussion in nextcloud/notes#51), I've extracted all changes I made there that do not belong to optimizations on the server API. Therefore, this PR is ready to merge and I will work on #167 later. This has the advantage that we can work on categories and do not have to wait until nextcloud/notes#51 is ready (and we have a smaller PR).

This PR includes:
- [x] synchronize (read-only) category and show category in `NotesListViewActivity` (cp. #165)
- [x] add `category` and `etag` to database (`etag` is not yet used, but will in the near future, see nextcloud/notes#56)
- [x] create database indexes (speed-up!)
- [x] reduce size of database-requests (only IDs instead of whole notes) in order to speed-up synchronization (significant for slow devices!)
- [x] NoteSQLiteOpenHelper has become a singleton (this was helpful during development)
- [x] some minor optimizations
