### PR TITLE
linkify URLs in preview

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NoteActivity.java
@@ -27,7 +27,6 @@ public class NoteActivity extends AppCompatActivity {
 
     private DBNote note = null;
     private RxMDTextView noteContent = null;
-    private ActionBar actionBar = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -37,14 +36,29 @@ public class NoteActivity extends AppCompatActivity {
         if (savedInstanceState != null) {
             note = (DBNote) savedInstanceState.getSerializable(PARAM_NOTE);
         }
-        actionBar = getSupportActionBar();
+        ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setTitle(note.getTitle());
             actionBar.setSubtitle(DateUtils.getRelativeDateTimeString(getApplicationContext(), note.getModified().getTimeInMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0));
         }
         noteContent = (RxMDTextView) findViewById(R.id.single_note_content);
 
-        RxMarkdown.with(note.getContent(), this)
+        String content = note.getContent();
+        /*
+         * The following replaceAll adds links ()[] to all URLs that are not in an existing link.
+         * This regular expression consists of three parts:
+         * 1. (?<![(])
+         *    negative look-behind: no opening bracket "(" directly before the URL
+         *    This prevents replacement in target part of Markdown link: [](URL)
+         * 2. (https?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])
+         *    URL pattern: matches all addresses beginning with http:// or https://
+         * 3. (?![^\\[]*\\])
+         *    negative look-ahead: no closing bracket "]" after the URL (otherwise there have to be an opening bracket "[" before)
+         *    This prevents replacement in label part of Markdown link: [...URL...]()
+         */
+        content = content.replaceAll("(?<![(])(https?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])(?![^\\[]*\\])", "[$1]($1)");
+
+        RxMarkdown.with(content, this)
                 .config(MarkDownUtil.getMarkDownConfiguration(getApplicationContext()))
                 .factory(TextFactory.create())
                 .intoObservable()
@@ -57,7 +71,7 @@ public class NoteActivity extends AppCompatActivity {
 
                     @Override
                     public void onError(Throwable e) {
-                        Log.v("Note View -------------", e.getStackTrace().toString());
+                        Log.v(getClass().getSimpleName(), "RxMarkdown error", e);
                     }
 
                     @Override
@@ -65,7 +79,7 @@ public class NoteActivity extends AppCompatActivity {
                         noteContent.setText(charSequence, TextView.BufferType.SPANNABLE);
                     }
                 });
-        noteContent.setText(note.getContent());
+        noteContent.setText(content);
         findViewById(R.id.fab_edit).setVisibility(View.GONE);
         ((TextView) findViewById(R.id.single_note_content)).setMovementMethod(LinkMovementMethod.getInstance());
     }


### PR DESCRIPTION
For the notes preview, I've written a regular expression which adds Markdown links `[]()` to URLs, so that they will be click-able. The regular expression does not apply to URLs in existing links (see explanation in the code comments).

Maybe, the RxMD library will have this feature sometime, too -- but until then, we can use this hack.

Furthermore, some minor code improvements were done.