### PR TITLE
update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ jdk: oraclejdk8
 android:
   components:
     - tools
-    - build-tools-25.0.2
-    - android-25
+    - build-tools-26.0.1
+    - android-26
     - extra-android-m2repository
 
 script: ./gradlew testDebug

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "it.niedermann.owncloud.notes"
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 16
         versionName "0.11.0"
     }
@@ -27,9 +27,9 @@ dependencies {
     compile project(':cert4android')
 
     compile 'com.yydcdut:rxmarkdown:0.1.0'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.android.support:support-v4:26.0.1'
+    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:design:26.0.1'
+    compile 'com.android.support:recyclerview-v7:26.0.1'
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,5 +16,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }


### PR DESCRIPTION
- [x] cert4android
- [x] support libraries
- [x] build-tools
- [x] sdk version (Android O)

Note: From support library 26.0.0, the minimum SDK version has been increased to 14! And: The support libraries are now available through Google's Maven repository. This led to two other changes, here.