### PR TITLE
use style to set text color in AlertDialog.

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/CategoryDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/CategoryDialogFragment.java
@@ -40,7 +40,7 @@ public class CategoryDialogFragment extends DialogFragment {
         if(savedInstanceState==null) {
             textCategory.setText(getArguments().getString(PARAM_CATEGORY));
         }
-        return new AlertDialog.Builder(getActivity())
+        return new AlertDialog.Builder(getActivity(), R.style.ocAlertDialog)
                 .setTitle(R.string.change_category_title)
                 .setView(dialogView)
                 .setMessage(R.string.change_category_message)

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,6 +22,10 @@
     <style name="Widget.AppCompat.Button.Borderless.Colored" parent="Widget.AppCompat.Button.Borderless">
     </style>
 
+    <style name="ocAlertDialog" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
+        <item name="colorAccent">@color/primary</item>
+    </style>
+
     <style name="fab">
         <item name="android:layout_margin">16dp</item>
         <item name="android:layout_width">wrap_content</item>


### PR DESCRIPTION
on a device with Android7 dialog buttons are not visible (white text on white background).