### PR TITLE
Single note widget scroll

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
             android:label="@string/menu_edit"
             android:parentActivityName="it.niedermann.owncloud.notes.android.activity.NotesListViewActivity"
             android:windowSoftInputMode="stateVisible"
-            android:launchMode="singleTask"
+            android:launchMode="singleInstance"
             />
 
         <activity
@@ -111,5 +111,10 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/single_note_widget_provider_info" />
         </receiver>
+
+        <service
+            android:name=".persistence.SingleNoteWidgetService"
+            android:permission="android.permission.BIND_REMOTEVIEWS" />
+
     </application>
 </manifest>

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SelectSingleNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SelectSingleNoteActivity.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -26,24 +27,28 @@ public class SelectSingleNoteActivity extends NotesListViewActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        ColorDrawable color;
+        android.support.v7.app.ActionBar ab = getSupportActionBar();
+        SwipeRefreshLayout swipeRefreshLayout = getSwipeRefreshLayout();
+
         setResult(Activity.RESULT_CANCELED);
         findViewById(R.id.fab_create).setVisibility(View.INVISIBLE);
-        getSupportActionBar().setTitle(R.string.activity_select_single_note);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            ColorDrawable colorDrawable = new ColorDrawable(getColor(R.color.bg_highlighted));
-            getSupportActionBar().setBackgroundDrawable(colorDrawable);
+            color = new ColorDrawable(getColor(R.color.bg_highlighted));
+        } else {
+            color = new ColorDrawable(ContextCompat.getColor(getApplicationContext(),
+                                                                R.color.bg_highlighted));
         }
 
-        Spannable title = new SpannableString(getSupportActionBar().getTitle());
-        title.setSpan(
-                new ForegroundColorSpan(getResources().getColor(R.color.primary)),
-                0,
-                title.length(),
-                Spannable.SPAN_INCLUSIVE_INCLUSIVE);
-        getSupportActionBar().setTitle(title);
-
-        SwipeRefreshLayout swipeRefreshLayout = getSwipeRefreshLayout();
+        ab.setBackgroundDrawable(color);
+        ab.setTitle(R.string.activity_select_single_note);
+        Spannable title = new SpannableString(ab.getTitle());
+        title.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.primary)),
+                                                0,
+                                                title.length(),
+                                                Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+        ab.setTitle(title);
         swipeRefreshLayout.setEnabled(false);
         swipeRefreshLayout.setRefreshing(false);
         initList();

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SingleNoteWidget.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SingleNoteWidget.java
@@ -7,77 +7,75 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.widget.RemoteViews;
 
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.model.DBNote;
-import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
+import it.niedermann.owncloud.notes.persistence.SingleNoteWidgetService;
 
 import static android.appwidget.AppWidgetManager.ACTION_APPWIDGET_UPDATE;
 
 public class SingleNoteWidget extends AppWidgetProvider {
 
     public static final String  WIDGET_KEY = "single_note_widget";
-    private static final String TAG = SingleNoteWidget.class.getSimpleName();
-
-    @Override
-    public void onEnabled(Context context) {
-        super.onEnabled(context);
-    }
 
     @Override
     public void onDeleted(Context context, int[] appWidgetIds) {
-        super.onDeleted(context, appWidgetIds);
-
-        SharedPreferences.Editor sharedprefs = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        SharedPreferences.Editor editor = PreferenceManager
+                                            .getDefaultSharedPreferences(context).edit();
 
         for (int appWidgetId : appWidgetIds) {
-            sharedprefs.remove(WIDGET_KEY + appWidgetId);
+            editor.remove(WIDGET_KEY + appWidgetId);
         }
-        sharedprefs.apply();
-    }
 
-    static void updateAppWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId) {
-        SharedPreferences sharedprefs = PreferenceManager.getDefaultSharedPreferences(context);
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_single_note);
-        long noteID = sharedprefs.getLong(SingleNoteWidget.WIDGET_KEY + appWidgetId, -1);
-
-        if (noteID >= 0) {
-            NoteSQLiteOpenHelper db = NoteSQLiteOpenHelper.getInstance(context);
-            DBNote note = db.getNote(noteID);
-            Intent intent = new Intent(context, EditNoteActivity.class);
-            intent.putExtra(EditNoteActivity.PARAM_NOTE, note);
-            intent.putExtra(EditNoteActivity.PARAM_WIDGET_SRC, true);
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-            views.setOnClickPendingIntent(R.id.widget_single_note, pendingIntent);
-            views.setTextViewText(R.id.single_note_content, note.getContent());
-            appWidgetManager.updateAppWidget(appWidgetId, views);
-        } else {
-            Log.e(TAG, "Note not found");
-            views.setTextViewText(R.id.single_note_content, "Note not found");
-            appWidgetManager.updateAppWidget(appWidgetId, views);
-        }
+        editor.apply();
+        super.onDeleted(context, appWidgetIds);
     }
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
         for (int appWidgetId : appWidgetIds) {
-            updateAppWidget(context, appWidgetManager, appWidgetId);
+            Intent templateIntent = new Intent(context, EditNoteActivity.class);
+            templateIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+
+            PendingIntent templatePendingIntent = PendingIntent.getActivity(
+                                                    context,
+                                                    0,
+                                                    templateIntent,
+                                                    PendingIntent.FLAG_UPDATE_CURRENT);
+
+
+            Intent serviceIntent = new Intent(context, SingleNoteWidgetService.class);
+            RemoteViews views = new RemoteViews(context.getPackageName(),
+                                                        R.layout.widget_single_note);
+
+            serviceIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+            serviceIntent.setData(Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME)));
+
+            views.setPendingIntentTemplate(R.id.single_note_widget_lv, templatePendingIntent);
+            views.setRemoteAdapter(R.id.single_note_widget_lv, serviceIntent);
+            views.setEmptyView(R.id.single_note_widget_lv, R.id.widget_single_note_placeholder_tv);
+            appWidgetManager.updateAppWidget(appWidgetId, views);
         }
+
+        super.onUpdate(context, appWidgetManager, appWidgetIds);
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
         AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
-        int ids[] = appWidgetManager.getAppWidgetIds(new ComponentName(context, SingleNoteWidget.class));
+        int ids[] = appWidgetManager.getAppWidgetIds(new ComponentName(context,
+                                                                        SingleNoteWidget.class));
 
         for (int appWidgetId : ids) {
             if (ACTION_APPWIDGET_UPDATE.equals(intent.getAction())) {
-                updateAppWidget(context, appWidgetManager, appWidgetId);
+                appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId,
+                                                                R.id.single_note_widget_lv);
             }
         }
+
         super.onReceive(context, intent);
     }
+    
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/SingleNoteWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/SingleNoteWidgetFactory.java
@@ -1,0 +1,110 @@
+package it.niedermann.owncloud.notes.model;
+
+import android.appwidget.AppWidgetManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.widget.RemoteViews;
+import android.widget.RemoteViewsService;
+
+import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.android.activity.EditNoteActivity;
+import it.niedermann.owncloud.notes.android.activity.SingleNoteWidget;
+import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
+
+public class SingleNoteWidgetFactory implements RemoteViewsService.RemoteViewsFactory {
+    private Context mContext;
+    private int mAppWidgetId;
+    private static final String TAG = SingleNoteWidget.class.getSimpleName();
+
+    public SingleNoteWidgetFactory(Context context, Intent intent) {
+        mContext = context;
+        mAppWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID,
+                                            AppWidgetManager.INVALID_APPWIDGET_ID);
+    }
+
+    @Override
+    public void onCreate() {
+
+    }
+
+    @Override
+    public boolean hasStableIds() {
+        return true;
+    }
+
+    @Override
+    public RemoteViews getLoadingView() {
+        return null;
+    }
+
+    @Override
+    public int getViewTypeCount() {
+        return 1;
+    }
+
+    @Override
+    public void onDataSetChanged() {
+
+    }
+
+    @Override
+    public void onDestroy() {
+
+    }
+
+    /**
+     * getCount() always runs 1 because the list view only ever has a
+     * single note displayed
+     * @return
+     */
+    @Override
+    public int getCount() {
+        return 1;
+    }
+
+    /**
+     * getViewAt -          Returns a RemoteView containing the note content in a TextView and
+     *                      a fillInIntent to handle the user tapping on the item in the list
+     *                      view.
+     *
+     * @param   position    The position of the item in the list
+     * @return              The RemoteView at the specified position in the list
+     */
+    @Override
+    public RemoteViews getViewAt(int position) {
+        RemoteViews note_content = new RemoteViews(mContext.getPackageName(),
+                R.layout.widget_single_note_content);
+        SharedPreferences sharedprefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        long noteID = sharedprefs.getLong(SingleNoteWidget.WIDGET_KEY + mAppWidgetId, -1);
+
+        if (noteID >= 0) {
+            NoteSQLiteOpenHelper db = NoteSQLiteOpenHelper.getInstance(mContext);
+            DBNote note = db.getNote(noteID);
+
+            final Intent fillInIntent = new Intent();
+            final Bundle extras = new Bundle();
+
+            extras.putSerializable(EditNoteActivity.PARAM_NOTE, note);
+            extras.putBoolean(EditNoteActivity.PARAM_WIDGET_SRC, true);
+
+            fillInIntent.putExtras(extras);
+            fillInIntent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+            note_content.setOnClickFillInIntent(R.id.single_note_content_tv, fillInIntent);
+            note_content.setTextViewText(R.id.single_note_content_tv, note.getContent());
+        } else {
+            Log.e(TAG, "Note not found");
+            note_content.setTextViewText(R.id.single_note_content_tv, "Note not found");
+        }
+
+        return note_content;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/SingleNoteWidgetService.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/SingleNoteWidgetService.java
@@ -1,0 +1,18 @@
+package it.niedermann.owncloud.notes.persistence;
+
+import android.content.Intent;
+import android.widget.RemoteViewsService;
+
+import it.niedermann.owncloud.notes.model.SingleNoteWidgetFactory;
+
+/**
+ * Created by dan0xii on 06/09/17.
+ *
+ */
+
+public class SingleNoteWidgetService extends RemoteViewsService {
+    @Override
+    public RemoteViewsFactory onGetViewFactory(Intent intent) {
+        return new SingleNoteWidgetFactory(this.getApplicationContext(), intent);
+    }
+}

--- a/app/src/main/res/layout/widget_single_note.xml
+++ b/app/src/main/res/layout/widget_single_note.xml
@@ -1,24 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/widget_single_note"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/widget_background"
-    android:padding="@dimen/widget_single_note_padding"
-    android:clickable="true">
+    >
 
-    <TextView
-        android:id="@+id/single_note_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="@color/fg_default"
+    <ListView
+        android:id="@+id/single_note_widget_lv"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/widget_background"
+        android:padding="@dimen/widget_single_note_padding"
+        android:divider="@null"
         />
+
+    <TextView
+        android:id="@+id/widget_single_note_placeholder_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center"/>
 </RelativeLayout>
 
     <!--
         TODO: Markdown support
 
         <com.yydcdut.rxmarkdown.RxMDTextView
+
+
     -->

--- a/app/src/main/res/layout/widget_single_note_content.xml
+++ b/app/src/main/res/layout/widget_single_note_content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/single_note_content_tv"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:textColor="@color/fg_default"
+    />

--- a/app/src/main/res/xml/single_note_widget_provider_info.xml
+++ b/app/src/main/res/xml/single_note_widget_provider_info.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:configure="it.niedermann.owncloud.notes.android.activity.SelectSingleNoteActivity"
     android:initialLayout="@layout/widget_single_note"
+    android:configure="it.niedermann.owncloud.notes.android.activity.SelectSingleNoteActivity"
     android:minHeight="110dp"
     android:minWidth="180dp"
     android:minResizeHeight="80dp"
     android:minResizeWidth="80dp"
+    android:autoAdvanceViewId="@id/single_note_widget_lv"
     android:previewImage="@drawable/single_note_widget3"
     android:resizeMode="horizontal|vertical"
-    android:updatePeriodMillis="86400000"
+    android:updatePeriodMillis="0"
     android:widgetCategory="keyguard|home_screen" />


### PR DESCRIPTION
Allows the single note widget to scroll. A slight drawback is that if the height of the widget is greater than the listview containing the note, there will be a dead space below the note that can't be tapped to open the note -- the user must hit the note text.