### PR TITLE
Fix to single note widget

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
@@ -75,6 +75,26 @@ public class EditNoteActivity extends AppCompatActivity implements CategoryDialo
         }
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Intent intent = getIntent();
+        DBNote note = (DBNote) intent.getSerializableExtra(PARAM_NOTE);
+
+        // Does the note retrieved from the intent match the note currently
+        // being displayed by the app
+        if ((note.getId()) != fragment.getNote().getId()) {
+            originalNote = note;
+            createEditFragment(note);
+        }
+    }
+
     private void createEditFragment(DBNote note) {
         configureActionBar(note, false);
         fragment = NoteEditFragment.newInstance(note);

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SingleNoteWidget.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SingleNoteWidget.java
@@ -50,7 +50,7 @@ public class SingleNoteWidget extends AppWidgetProvider {
             Intent intent = new Intent(context, EditNoteActivity.class);
             intent.putExtra(EditNoteActivity.PARAM_NOTE, note);
             intent.putExtra(EditNoteActivity.PARAM_WIDGET_SRC, true);
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
             views.setOnClickPendingIntent(R.id.widget_single_note, pendingIntent);
             views.setTextViewText(R.id.single_note_content, note.getContent());
             appWidgetManager.updateAppWidget(appWidgetId, views);


### PR DESCRIPTION
Opening a note from the widget would have no effect if the user already had an editor
open for a different note (mentioned in #263). This change should check to see if a note is already being
edited, save and synchronise it and then present the new note for editing.

Unsure as to whether db.updateNoteAndSync is the best way to immediately save the note before overwriting it with the new one.