### PR TITLE
update support libs to 26.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,9 +27,12 @@ dependencies {
     compile project(':cert4android')
 
     compile 'com.yydcdut:rxmarkdown:0.1.0'
-    compile 'com.android.support:support-v4:26.0.1'
-    compile 'com.android.support:appcompat-v7:26.0.1'
-    compile 'com.android.support:design:26.0.1'
-    compile 'com.android.support:recyclerview-v7:26.0.1'
+
+    def supportLibVersion = '26.0.2';
+    compile "com.android.support:support-v4:${supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${supportLibVersion}"
+    compile "com.android.support:design:${supportLibVersion}"
+    compile "com.android.support:recyclerview-v7:${supportLibVersion}"
+    compile "com.android.support:cardview-v7:${supportLibVersion}" // needed for cert4android (conflict resolution)
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }


### PR DESCRIPTION
I needed to add `com.android.support:cardview-v7`(which is required by `cert4android`) in order to get the automatic conflict resolution from gradle to work. Now, we can update the support libs independently from cert4android.

Fixes #279