### PR TITLE
Convert line-breaks

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
@@ -85,6 +85,9 @@ public class NoteEditFragment extends Fragment implements NoteFragmentI {
         note = (DBNote) getArguments().getSerializable(PARAM_NOTE);
         db = NoteSQLiteOpenHelper.getInstance(getActivity());
 
+        // workaround for issue yydcdut/RxMarkdown#41
+        note.setContent(note.getContent().replace("\r\n", "\n"));
+
         final RxMDEditText content = getContentView();
         content.setText(note.getContent());
         content.setEnabled(true);


### PR DESCRIPTION
Workaround for yydcdut/RxMarkdown#41 (app crashes if the note contains an unordered list and uses windows-style line-breaks). It converts windows-style line-breaks (`\r\n`) to unix-style line-breaks (`\n`) if the user wants to edit a note. This conversion is saved only if the user performs any changes to the note. Fixes #215.

We can remove this workaround later, when yydcdut/RxMarkdown#41 is fixed upstream. But since this bug is very annoying, I suggest to merge this workaround in the meanwhile.