### PR TITLE
Refactor NoteFragments, category in ActionBar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,7 +72,7 @@
             android:label="@string/menu_edit"
             android:parentActivityName="it.niedermann.owncloud.notes.android.activity.NotesListViewActivity"
             android:windowSoftInputMode="stateHidden"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             />
 
         <activity

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
@@ -1,43 +1,59 @@
 package it.niedermann.owncloud.notes.android.activity;
 
 import android.app.Fragment;
-import android.app.FragmentManager;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.android.fragment.CategoryDialogFragment;
+import it.niedermann.owncloud.notes.android.fragment.BaseNoteFragment;
 import it.niedermann.owncloud.notes.android.fragment.NoteEditFragment;
-import it.niedermann.owncloud.notes.android.fragment.NoteFragmentI;
 import it.niedermann.owncloud.notes.android.fragment.NotePreviewFragment;
 import it.niedermann.owncloud.notes.model.DBNote;
-import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
+import it.niedermann.owncloud.notes.util.NoteUtil;
 
-public class EditNoteActivity extends AppCompatActivity implements CategoryDialogFragment.CategoryDialogListener {
+public class EditNoteActivity extends AppCompatActivity implements BaseNoteFragment.NoteFragmentListener {
 
-    public static final String PARAM_NOTE = "note";
-    public static final String PARAM_ORIGINAL_NOTE = "original_note";
-    public static final String PARAM_NOTE_POSITION = "note_position";
+    public static final String PARAM_NOTE_ID = "noteId";
 
-    private static final String LOG_TAG = "EditNote/SAVE";
-
-    private DBNote originalNote;
-    private int notePosition = 0;
-    private NoteSQLiteOpenHelper db;
-    private NoteFragmentI fragment;
+    private BaseNoteFragment fragment;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        DBNote note;
+
+        if (savedInstanceState == null) {
+            createFragmentByPreference();
+        } else {
+            fragment = (BaseNoteFragment) getFragmentManager().findFragmentById(android.R.id.content);
+        }
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Log.d(getClass().getSimpleName(), "onNewIntent: "+intent.getLongExtra(PARAM_NOTE_ID, 0));
+        setIntent(intent);
+        createFragmentByPreference();
+    }
+
+    private long getNoteId() {
+        return getIntent().getLongExtra(PARAM_NOTE_ID, 0);
+    }
+
+    private void createFragmentByPreference() {
+        long noteId = getNoteId();
+
         final String prefKeyNoteMode = getString(R.string.pref_key_note_mode);
         final String prefKeyLastMode = getString(R.string.pref_key_last_note_mode);
         final String prefValueEdit = getString(R.string.pref_value_mode_edit);
@@ -47,202 +63,72 @@ public class EditNoteActivity extends AppCompatActivity implements CategoryDialo
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         String mode = preferences.getString(prefKeyNoteMode, prefValueEdit);
         String lastMode = preferences.getString(prefKeyLastMode, prefValueEdit);
-
-        if (savedInstanceState == null) {
-            Log.d(getClass().getSimpleName(), "Starting from Intent");
-            note = originalNote = (DBNote) getIntent().getSerializableExtra(PARAM_NOTE);
-            notePosition = getIntent().getIntExtra(PARAM_NOTE_POSITION, 0);
-        } else {
-            Log.d(getClass().getSimpleName(), "Starting from SavedState");
-            note = (DBNote) savedInstanceState.getSerializable(PARAM_NOTE);
-            originalNote = (DBNote) savedInstanceState.getSerializable(PARAM_ORIGINAL_NOTE);
-            notePosition = savedInstanceState.getInt(PARAM_NOTE_POSITION);
-            mode = savedInstanceState.getString(prefKeyNoteMode);
-        }
-
-        db = NoteSQLiteOpenHelper.getInstance(this);
-
         if (prefValuePreview.equals(mode) || (prefValueLast.equals(mode) && prefValuePreview.equals(lastMode))) {
-            createPreviewFragment(note);
+            createFragment(noteId, false);
         /* TODO enhancement: store last mode in note
            for cross device functionality per note mode should be stored on the server.
         } else if(prefValueLast.equals(mode) && prefValuePreview.equals(note.getMode())) {
             createPreviewFragment(note);
          */
         } else {
-            createEditFragment(note);
+            createFragment(noteId, true);
         }
     }
 
-    @Override
-    protected void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        setIntent(intent);
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Intent intent = getIntent();
-        DBNote note = (DBNote) intent.getSerializableExtra(PARAM_NOTE);
-
-        // Does the note retrieved from the intent match the note currently
-        // being displayed by the app
-        if ((note.getId()) != fragment.getNote().getId()) {
-            originalNote = note;
-            createEditFragment(note);
+    private void createFragment(long noteId, boolean edit) {
+        // save state of the fragment in order to resume with the same note and originalNote
+        Fragment.SavedState savedState = null;
+        if(fragment != null) {
+            savedState = getFragmentManager().saveFragmentInstanceState(fragment);
         }
-    }
-
-    private void createEditFragment(DBNote note) {
-        configureActionBar(note, false);
-        fragment = NoteEditFragment.newInstance(note);
-        getFragmentManager().beginTransaction().replace(android.R.id.content, (Fragment) fragment).commit();
-    }
-
-    private void createPreviewFragment(DBNote note) {
-        configureActionBar(note, true);
-        fragment = NotePreviewFragment.newInstance(note);
-        getFragmentManager().beginTransaction().replace(android.R.id.content, (Fragment) fragment).commit();
-    }
-
-    private void configureActionBar(DBNote note, boolean timestamp) {
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setTitle(note.getTitle());
-            if (timestamp) {
-                actionBar.setSubtitle(DateUtils.getRelativeDateTimeString(getApplicationContext(), note.getModified().getTimeInMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0));
-            } else {
-                actionBar.setSubtitle(getString(R.string.action_edit_editing));
-            }
-
-            actionBar.setDisplayHomeAsUpEnabled(true);
+        if(edit) {
+            fragment = NoteEditFragment.newInstance(noteId);
+        } else {
+            fragment = NotePreviewFragment.newInstance(noteId);
         }
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putSerializable(PARAM_NOTE, fragment.getNote());
-        outState.putSerializable(PARAM_ORIGINAL_NOTE, originalNote);
-        outState.putInt(PARAM_NOTE_POSITION, notePosition);
-        final String prefKeyNoteMode = getString(R.string.pref_key_note_mode);
-        if(fragment instanceof  NotePreviewFragment)
-            outState.putString(prefKeyNoteMode, getString(R.string.pref_value_mode_preview));
-        else
-            outState.putString(prefKeyNoteMode, getString(R.string.pref_value_mode_edit));
-        super.onSaveInstanceState(outState);
+        if(savedState != null) {
+            fragment.setInitialSavedState(savedState);
+        }
+        getFragmentManager().beginTransaction().replace(android.R.id.content, fragment).commit();
     }
 
     @Override
     public void onBackPressed() {
-        close(fragment.getNote());
+        fragment.onPrepareClose();
+        close();
     }
 
-    /**
-     * Main-Menu
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_note_list_view, menu);
-        return true;
+        getMenuInflater().inflate(R.menu.menu_note_activity, menu);
+        return super.onCreateOptionsMenu(menu);
     }
 
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        MenuItem itemFavorite = menu.findItem(R.id.menu_favorite);
-        prepareFavoriteOption(itemFavorite);
-        return super.onPrepareOptionsMenu(menu);
-    }
-
-    private void prepareFavoriteOption(MenuItem item) {
-        DBNote note = fragment.getNote();
-        item.setIcon(note.isFavorite() ? R.drawable.ic_star_white_24dp : R.drawable.ic_star_outline_white_24dp);
-        item.setChecked(note.isFavorite());
-    }
-
-    /**
-     * Main-Menu-Handler
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                close(fragment.getNote());
-                return true;
-            case R.id.menu_cancel:
-                Log.d(LOG_TAG, "CANCEL: original: " + originalNote);
-                db.updateNoteAndSync(originalNote, null, null);
-                close(originalNote);
-                return true;
-            case R.id.menu_delete:
-                db.deleteNoteAndSync(originalNote.getId());
-                Intent data = new Intent();
-                data.putExtra(PARAM_NOTE_POSITION, notePosition);
-                setResult(RESULT_FIRST_USER, data);
-                finish();
-                return true;
-            case R.id.menu_favorite:
-                db.toggleFavorite(fragment.getNote(), null);
-                prepareFavoriteOption(item);
-                return true;
-            case R.id.menu_category:
-                showCategorySelector();
+                fragment.onPrepareClose();
+                close();
                 return true;
             case R.id.menu_preview:
-                createPreviewFragment(fragment.getNote());
+                fragment.onPrepareClose();
+                createFragment(getNoteId(), false);
                 return true;
             case R.id.menu_edit:
-                createEditFragment(fragment.getNote());
+                fragment.onPrepareClose();
+                createFragment(getNoteId(), true);
                 return true;
-            case R.id.menu_share:
-                Intent shareIntent = new Intent();
-                shareIntent.setAction(Intent.ACTION_SEND);
-                shareIntent.setType("text/plain");
-                DBNote note = fragment.getNote();
-                shareIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, note.getTitle());
-                shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, note.getContent());
-                startActivity(shareIntent);
-                return true;
-            /*case R.id.menu_copy:
-                db = new NoteSQLiteOpenHelper(this);
-                Note newNote = db.getNote(db.addNoteAndSync(note.getContent()));
-                newNote.setTitle(note.getTitle() + " (" + getResources().getString(R.string.copy) + ")");
-                db.updateNote(newNote);
-                finish();
-                return true;*/
             default:
                 return super.onOptionsItemSelected(item);
         }
     }
 
-    /**
-     * Opens a dialog in order to chose a category
-     */
-    private void showCategorySelector() {
-        final String fragmentId = "fragment_category";
-        FragmentManager manager = getFragmentManager();
-        Fragment frag = manager.findFragmentByTag(fragmentId);
-        if(frag!=null) {
-            manager.beginTransaction().remove(frag).commit();
-        }
-        Bundle arguments = new Bundle();
-        arguments.putString(CategoryDialogFragment.PARAM_CATEGORY, fragment.getNote().getCategory());
-        CategoryDialogFragment categoryFragment = new CategoryDialogFragment();
-        categoryFragment.setArguments(arguments);
-        categoryFragment.show(manager, fragmentId);
-    }
-
-    @Override
-    public void onCategoryChosen(String category) {
-        DBNote note = fragment.getNote();
-        db.setCategory(note, category, null);
-    }
 
     /**
      * Send result and closes the Activity
      */
-    private void close(DBNote note) {
+    public void close() {
         /* TODO enhancement: store last mode in note
         * for cross device functionality per note mode should be stored on the server.
         */
@@ -253,14 +139,16 @@ public class EditNoteActivity extends AppCompatActivity implements CategoryDialo
         } else {
             preferences.edit().putString(prefKeyLastMode, getString(R.string.pref_value_mode_preview)).apply();
         }
-
-        Intent data = new Intent();
-        data.setAction(Intent.ACTION_VIEW);
-        data.putExtra(PARAM_NOTE, note);
-        data.putExtra(PARAM_NOTE_POSITION, notePosition);
-        setResult(RESULT_OK, data);
-        db.updateSingleNoteWidgets();
-        db.updateNoteListWidgets();
         finish();
+    }
+
+    @Override
+    public void onNoteUpdated(DBNote note) {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setTitle(note.getTitle());
+            String subtitle = note.getCategory().isEmpty() ? getString(R.string.action_uncategorized) : NoteUtil.extendCategory(note.getCategory());
+            actionBar.setSubtitle(subtitle);
+        }
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -542,21 +542,6 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
                 adapter.add(createdNote);
                 // TODO scroll to top
             }
-        } else if (requestCode == show_single_note_cmd) {
-            if (resultCode == RESULT_OK || resultCode == RESULT_FIRST_USER) {
-                int notePosition = data.getExtras().getInt(EditNoteActivity.PARAM_NOTE_POSITION);
-                if(adapter.getItemCount()>notePosition) {
-                    Item oldItem = adapter.getItem(notePosition);
-                    if (resultCode == RESULT_FIRST_USER) {
-                        adapter.remove(oldItem);
-                    }
-                    if (resultCode == RESULT_OK) {
-                        DBNote editedNote = (DBNote) data.getExtras().getSerializable(EditNoteActivity.PARAM_NOTE);
-                        adapter.replace(editedNote, notePosition);
-                        refreshLists();
-                    }
-                }
-            }
         } else if (requestCode == server_settings) {
             // Create new Instance with new URL and credentials
             db = NoteSQLiteOpenHelper.getInstance(this);
@@ -598,10 +583,9 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
                 mActionMode.finish();
             }
         } else {
-            Item item = adapter.getItem(position);
+            DBNote note = (DBNote) adapter.getItem(position);
             Intent intent = new Intent(getApplicationContext(), EditNoteActivity.class);
-            intent.putExtra(EditNoteActivity.PARAM_NOTE, (DBNote) item);
-            intent.putExtra(EditNoteActivity.PARAM_NOTE_POSITION, position);
+            intent.putExtra(EditNoteActivity.PARAM_NOTE_ID, note.getId());
             startActivityForResult(intent, show_single_note_cmd);
 
         }

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/CategoryDialogFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/CategoryDialogFragment.java
@@ -155,7 +155,7 @@ public class CategoryDialogFragment extends DialogFragment {
 
                     for (int i = 0; i < count; i++) {
                         final String value = originalData.get(i);
-                        final String valueText = value.toString().toLowerCase();
+                        final String valueText = value.toLowerCase();
 
                         // First match against the whole, non-splitted value
                         if (valueText.startsWith(prefixString)) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteFragmentI.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteFragmentI.java
@@ -1,7 +1,0 @@
-package it.niedermann.owncloud.notes.android.fragment;
-
-import it.niedermann.owncloud.notes.model.DBNote;
-
-public interface NoteFragmentI {
-    public DBNote getNote();
-}

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
@@ -1,14 +1,11 @@
 package it.niedermann.owncloud.notes.android.fragment;
 
-import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -19,36 +16,19 @@ import com.yydcdut.rxmarkdown.RxMarkdown;
 import com.yydcdut.rxmarkdown.syntax.text.TextFactory;
 
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.android.activity.EditNoteActivity;
-import it.niedermann.owncloud.notes.model.DBNote;
 import it.niedermann.owncloud.notes.util.MarkDownUtil;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
-public class NotePreviewFragment extends Fragment implements NoteFragmentI {
+public class NotePreviewFragment extends BaseNoteFragment {
 
-    public static final String PARAM_NOTE = EditNoteActivity.PARAM_NOTE;
-
-    private DBNote note = null;
-
-    public static NotePreviewFragment newInstance(DBNote note) {
+    public static NotePreviewFragment newInstance(long noteId) {
         NotePreviewFragment f = new NotePreviewFragment();
         Bundle b = new Bundle();
-        b.putSerializable(PARAM_NOTE, note);
+        b.putSerializable(PARAM_NOTE_ID, noteId);
         f.setArguments(b);
         return f;
-    }
-
-    @Override
-    public DBNote getNote() {
-        return note;
-    }
-
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
     }
 
     @Override
@@ -70,8 +50,7 @@ public class NotePreviewFragment extends Fragment implements NoteFragmentI {
 
         getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
 
-        note = (DBNote) getArguments().getSerializable(PARAM_NOTE);
-        final RxMDTextView noteContent = (RxMDTextView) getActivity().findViewById(R.id.single_note_content);
+        final RxMDTextView noteContent = getActivity().findViewById(R.id.single_note_content);
 
         String content = note.getContent();
         /*
@@ -113,4 +92,8 @@ public class NotePreviewFragment extends Fragment implements NoteFragmentI {
         ((TextView) getActivity().findViewById(R.id.single_note_content)).setMovementMethod(LinkMovementMethod.getInstance());
     }
 
+    @Override
+    protected String getContent() {
+        return note.getContent();
+    }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/NoteListWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/NoteListWidgetFactory.java
@@ -70,7 +70,7 @@ public class NoteListWidgetFactory implements RemoteViewsService.RemoteViewsFact
         final Intent fillInIntent = new Intent();
         final Bundle extras = new Bundle();
 
-        extras.putSerializable(EditNoteActivity.PARAM_NOTE, note);
+        extras.putLong(EditNoteActivity.PARAM_NOTE_ID, note.getId());
         fillInIntent.putExtras(extras);
         fillInIntent.setData(Uri.parse(fillInIntent.toUri(Intent.URI_INTENT_SCHEME)));
         note_content.setOnClickFillInIntent(R.id.widget_note_list_entry, fillInIntent);

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/SingleNoteWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/SingleNoteWidgetFactory.java
@@ -98,7 +98,7 @@ public class SingleNoteWidgetFactory implements RemoteViewsService.RemoteViewsFa
         final Intent fillInIntent = new Intent();
         final Bundle extras = new Bundle();
 
-        extras.putSerializable(EditNoteActivity.PARAM_NOTE, note);
+        extras.putLong(EditNoteActivity.PARAM_NOTE_ID, note.getId());
         fillInIntent.putExtras(extras);
         fillInIntent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         note_content.setOnClickFillInIntent(R.id.single_note_content_tv, fillInIntent);

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
@@ -218,7 +218,6 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      * @param id int - ID of the requested Note
      * @return requested Note
      */
-    @SuppressWarnings("unused")
     public DBNote getNote(long id) {
         List<DBNote> notes = getNotesCustom(key_id + " = ? AND " + key_status + " != ?", new String[]{String.valueOf(id), DBStatus.LOCAL_DELETED.getTitle()}, null);
         return notes.isEmpty() ? null : notes.get(0);

--- a/app/src/main/res/menu/menu_note_activity.xml
+++ b/app/src/main/res/menu/menu_note_activity.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+    <item
+        android:id="@+id/menu_preview"
+        android:icon="@drawable/ic_eye_white_24dp"
+        android:orderInCategory="50"
+        android:title="@string/menu_preview"
+        app:showAsAction="ifRoom"
+        />
+    <item
+        android:id="@+id/menu_edit"
+        android:icon="@drawable/ic_action_edit_24dp"
+        android:orderInCategory="50"
+        android:title="@string/menu_edit"
+        app:showAsAction="ifRoom"
+        />
+</menu>

--- a/app/src/main/res/menu/menu_note_fragment.xml
+++ b/app/src/main/res/menu/menu_note_fragment.xml
@@ -2,18 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/menu_preview"
-        android:icon="@drawable/ic_eye_white_24dp"
-        android:orderInCategory="50"
-        android:title="@string/menu_preview"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/menu_edit"
-        android:icon="@drawable/ic_action_edit_24dp"
-        android:orderInCategory="50"
-        android:title="@string/menu_edit"
-        app:showAsAction="ifRoom" />
-    <item
         android:id="@+id/menu_favorite"
         android:orderInCategory="80"
         android:title="@string/menu_favorite"
@@ -31,12 +19,6 @@
         android:orderInCategory="100"
         android:title="@string/menu_share"
         app:showAsAction="never" />
-    <!--item
-        android:id="@+id/menu_copy"
-        android:icon="@drawable/ic_action_copy"
-        android:orderInCategory="110"
-        app:showAsAction="never"
-        android:title="@string/menu_copy"/-->
     <item
         android:id="@+id/menu_cancel"
         android:icon="@drawable/ic_action_cancel"


### PR DESCRIPTION
Complete refactoring of `EditNoteActivity`, `NoteFragmentI`, `NoteEditFragment` and `NotePreviewFragment`. **Please don't start big changes on these classes until this PR is finished.**

- [x] display category in ActionBar's subtitle (fixes #285)
- [x] complete refactoring: separate functionalities:
  - `EditNoteActivity`: management of fragments (start intended view/edit mode and save state) and calling from app and widget
  - `BaseNoteFragment`: handling of note (loading, saving), menu and ActionBar and respective actions on them
  - `NoteEditFragment`: handling auto-save
  - `NotePreviewFragment`: just display the note
- [x] Fixes doubled instantiation of fragments when rotating
- [x] depends on #275
- [ ] make category in ActionBar clickable