### PR TITLE
Moved widget update functions 

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/BaseNoteFragment.java
@@ -139,8 +139,6 @@ public abstract class BaseNoteFragment extends Fragment implements CategoryDialo
     protected void saveNote(@Nullable ICallback callback) {
         Log.d(getClass().getSimpleName(), "saveData()");
         note = db.updateNoteAndSync(note, getContent(), callback);
-        db.updateSingleNoteWidgets();
-        db.updateNoteListWidgets();
         listener.onNoteUpdated(note);
     }
     protected abstract String getContent();

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
@@ -178,9 +178,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
     public long addNoteAndSync(CloudNote note) {
         DBNote dbNote =  new DBNote(0, 0, note.getModified(), note.getTitle(), note.getContent(), note.isFavorite(), note.getCategory(), note.getEtag(), DBStatus.LOCAL_EDITED);
         long id = addNote(dbNote);
+        notifyNotesChanged();
         getNoteServerSyncHelper().scheduleSync(true);
-        updateSingleNoteWidgets();
-        updateNoteListWidgets();
         return id;
     }
 
@@ -442,8 +441,7 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         int rows = db.update(table_notes, values, key_id + " = ? AND (" + key_content + " != ? OR " + key_category + " != ?)", new String[]{String.valueOf(newNote.getId()), newNote.getContent(), newNote.getCategory()});
         // if data was changed, set new status and schedule sync (with callback); otherwise invoke callback directly.
         if(rows > 0) {
-            updateSingleNoteWidgets();
-            updateNoteListWidgets();
+            notifyNotesChanged();
             if(callback!=null) {
                 serverSyncHelper.addCallbackPush(callback);
             }
@@ -522,10 +520,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
                 values,
                 key_id + " = ?",
                 new String[]{String.valueOf(id)});
+        notifyNotesChanged();
         getNoteServerSyncHelper().scheduleSync(true);
-        updateSingleNoteWidgets();
-        updateNoteListWidgets();
-
         return i;
     }
 
@@ -543,12 +539,18 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
                 new String[]{String.valueOf(id), forceDBStatus.getTitle()});
     }
 
+    /**
+     * Notify about changed notes.
+     */
+    void notifyNotesChanged() {
+        updateSingleNoteWidgets();
+        updateNoteListWidgets();
+    }
 
     /**
      * Update single note widget, if the note data was changed.
-     * TODO This should be replaced by using the observer pattern
      */
-    public void updateSingleNoteWidgets() {
+    private void updateSingleNoteWidgets() {
         Intent intent = new Intent(getContext(), SingleNoteWidget.class);
         intent.setAction("android.appwidget.action.APPWIDGET_UPDATE");
         getContext().sendBroadcast(intent);
@@ -556,9 +558,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
 
     /**
      * Update note list widgets, if the note data was changed.
-     * TODO This should be replaced by using the observer pattern
      */
-    public void updateNoteListWidgets() {
+    private void updateNoteListWidgets() {
         Intent intent = new Intent(getContext(), NoteListWidget.class);
         intent.setAction("android.appwidget.action.APPWIDGET_UPDATE");
         getContext().sendBroadcast(intent);

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
@@ -179,6 +179,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         DBNote dbNote =  new DBNote(0, 0, note.getModified(), note.getTitle(), note.getContent(), note.isFavorite(), note.getCategory(), note.getEtag(), DBStatus.LOCAL_EDITED);
         long id = addNote(dbNote);
         getNoteServerSyncHelper().scheduleSync(true);
+        updateSingleNoteWidgets();
+        updateNoteListWidgets();
         return id;
     }
 
@@ -440,6 +442,8 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
         int rows = db.update(table_notes, values, key_id + " = ? AND (" + key_content + " != ? OR " + key_category + " != ?)", new String[]{String.valueOf(newNote.getId()), newNote.getContent(), newNote.getCategory()});
         // if data was changed, set new status and schedule sync (with callback); otherwise invoke callback directly.
         if(rows > 0) {
+            updateSingleNoteWidgets();
+            updateNoteListWidgets();
             if(callback!=null) {
                 serverSyncHelper.addCallbackPush(callback);
             }
@@ -519,6 +523,9 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
                 key_id + " = ?",
                 new String[]{String.valueOf(id)});
         getNoteServerSyncHelper().scheduleSync(true);
+        updateSingleNoteWidgets();
+        updateNoteListWidgets();
+
         return i;
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
@@ -38,8 +38,6 @@ import it.niedermann.owncloud.notes.util.NotesClientUtil.LoginStatus;
 import it.niedermann.owncloud.notes.util.ServerResponse;
 import it.niedermann.owncloud.notes.util.SupportUtil;
 
-import static android.content.ContentValues.TAG;
-
 /**
  * Helps to synchronize the Database to the Server.
  */
@@ -395,9 +393,7 @@ public class NoteServerSyncHelper {
             for (ICallback callback : callbacks) {
                 callback.onFinish();
             }
-            Log.d(TAG, "onPostExecute: Update widgets");
-            dbHelper.updateSingleNoteWidgets();
-            dbHelper.updateNoteListWidgets();
+            dbHelper.notifyNotesChanged();
             // start next sync if scheduled meanwhile
             if(syncScheduled) {
                 scheduleSync(false);


### PR DESCRIPTION
Moved widget update functions from NoteServerSyncHelper to NoteSQLLiteOpenHelper to allow the widgets to be updated without having to wait for a sync with the server.

Currently there is a bug where you can crash the app after deleting a note via the Note List Widget. Steps to reproduce:

1. Select a note from the Note List Widget so that you're presented with the edit note window.
2. Go to the context menu and delete the note, you'll be dropped back to your home screen.
3. The Note List Widget still displays the note in its list that you've just deleted.
4. Tap it again and you get a crash.