### PR TITLE
release v0.13.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "it.niedermann.owncloud.notes"
         minSdkVersion 14
         targetSdkVersion 26
-        versionCode 18
-        versionName "0.12.1"
+        versionCode 20
+        versionName "0.13.1"
     }
     buildTypes {
         release {


### PR DESCRIPTION
`app/build.gradle` wasn't updated before tagging version `v0.13.0`! Now, we have a tag `v0.13.0` with version name `0.12.1`. Can this be a problem with the automatic releases on F-Droid?

I suggest to go directly to `0.13.1` (tag and `build.gradle`) in order to avoid problems.