### PR TITLE
Single note widget minimum height changed from two rows to one.

### DIFF
--- a/app/src/main/res/xml/single_note_widget_provider_info.xml
+++ b/app/src/main/res/xml/single_note_widget_provider_info.xml
@@ -4,7 +4,7 @@
     android:configure="it.niedermann.owncloud.notes.android.activity.SelectSingleNoteActivity"
     android:minHeight="110dp"
     android:minWidth="180dp"
-    android:minResizeHeight="80dp"
+    android:minResizeHeight="40dp"
     android:minResizeWidth="80dp"
     android:autoAdvanceViewId="@id/single_note_widget_lv"
     android:previewImage="@drawable/single_note_widget3"


### PR DESCRIPTION
As requested in #343.

Closes #343