### PR TITLE
remove obsolete library support-v4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 
     def supportLibVersion = '27.1.1'
 
-    implementation "com.android.support:support-v4:${supportLibVersion}"
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:design:${supportLibVersion}"
     implementation "com.android.support:recyclerview-v7:${supportLibVersion}"


### PR DESCRIPTION
This was used by the old notification "New Note" and is obsolete, now.