### PR TITLE
always show sync progress

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -558,7 +558,6 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
             db = NoteSQLiteOpenHelper.getInstance(this);
             if (db.getNoteServerSyncHelper().isSyncPossible()) {
                 adapter.removeAll();
-                swipeRefreshLayout.setRefreshing(true);
                 synchronize();
             } else {
                 Toast.makeText(getApplicationContext(), getString(R.string.error_sync, getString(NotesClientUtil.LoginStatus.NO_NETWORK.str)), Toast.LENGTH_LONG).show();
@@ -633,6 +632,7 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
     }
 
     private void synchronize() {
+        swipeRefreshLayout.setRefreshing(true);
         db.getNoteServerSyncHelper().addCallbackPull(syncCallBack);
         db.getNoteServerSyncHelper().scheduleSync(false);
     }


### PR DESCRIPTION
see #406:

> Another very simple enhancement would be that when you open the app and the initial sync is done, show the same feedback spinner as is shown when you pull to refresh. Then people know what's happening.