### PR TITLE
#422 Rxmarkdown update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,10 @@ android {
 dependencies {
     implementation project(':cert4android')
 
-    implementation 'com.yydcdut:rxmarkdown:0.1.1-beta'
-
+    implementation 'io.reactivex:rxandroid:1.2.0'
+    implementation 'io.reactivex:rxjava:1.1.5'
+    implementation 'com.yydcdut:markdown-processor:0.1.2'
+    implementation 'com.yydcdut:rxmarkdown-wrapper:0.1.2'
 
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
@@ -14,9 +14,9 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.TextView;
 
+import com.yydcdut.markdown.syntax.edit.EditFactory;
 import com.yydcdut.rxmarkdown.RxMDEditText;
 import com.yydcdut.rxmarkdown.RxMarkdown;
-import com.yydcdut.rxmarkdown.syntax.edit.EditFactory;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
@@ -91,7 +91,7 @@ public class NoteEditFragment extends BaseNoteFragment {
         editContent.setEnabled(true);
 
         RxMarkdown.live(editContent)
-                .config(MarkDownUtil.getMarkDownConfiguration(getActivity().getApplicationContext()))
+                .config(MarkDownUtil.getMarkDownConfiguration(getActivity().getApplicationContext()).build())
                 .factory(EditFactory.create())
                 .intoObservable()
                 .subscribe(new Subscriber<CharSequence>() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
@@ -24,6 +24,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.util.ICallback;
+import it.niedermann.owncloud.notes.util.MarkDownUtil;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
@@ -75,27 +76,22 @@ public class NotePreviewFragment extends BaseNoteFragment {
         content = content.replaceAll("(?<![(])(https?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])(?![^\\[]*\\])", "[$1]($1)");
 
         RxMarkdown.with(content, getActivity())
-                .config(new RxMDConfiguration.Builder(getActivity().getApplicationContext())
-                        .setHeader2RelativeSize(1.35f)
-                        .setHeader3RelativeSize(1.25f)
-                        .setHeader4RelativeSize(1.15f)
-                        .setHeader5RelativeSize(1.1f)
-                        .setHeader6RelativeSize(1.05f)
-                        .setHorizontalRulesHeight(2)
+                .config(
+                    MarkDownUtil.getMarkDownConfiguration(getActivity().getApplicationContext())
                         .setOnTodoClickCallback(new OnTodoClickCallback() {
-                            @Override
-                            public CharSequence onTodoClicked(View view, String line, int lineNumber) {
+                                @Override
+                                public CharSequence onTodoClicked(View view, String line, int lineNumber) {
                                 String[] lines = TextUtils.split(note.getContent(), "\\r?\\n");
                                 if(lines.length >= lineNumber) {
-                                    lines[lineNumber] = line + lines[lineNumber].charAt(lines[lineNumber].length() - 1);
+                                    lines[lineNumber] = line;
                                 }
                                 noteContent.setText(TextUtils.join("\n", lines), TextView.BufferType.SPANNABLE);
                                 saveNote(null);
                                 return line;
                             }
-                        })
-                        .setLinkFontColor(ResourcesCompat.getColor(getActivity().getApplicationContext().getResources(), R.color.primary, null))
-                        .build())
+                        }
+                    ).build()
+                )
                 .factory(TextFactory.create())
                 .intoObservable()
                 .subscribeOn(Schedulers.computation())

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
@@ -10,9 +10,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.yydcdut.markdown.syntax.text.TextFactory;
 import com.yydcdut.rxmarkdown.RxMDTextView;
 import com.yydcdut.rxmarkdown.RxMarkdown;
-import com.yydcdut.rxmarkdown.syntax.text.TextFactory;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/MarkDownUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/MarkDownUtil.java
@@ -27,7 +27,7 @@ public class MarkDownUtil {
                 .setHeader5RelativeSize(1.1f)
                 .setHeader6RelativeSize(1.05f)
                 .setHorizontalRulesHeight(2)
-                .setLinkColor(ResourcesCompat.getColor(context.getResources(), R.color.primary, null))
+                .setLinkFontColor(ResourcesCompat.getColor(context.getResources(), R.color.primary, null))
                 .build();
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/MarkDownUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/MarkDownUtil.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.support.v4.content.res.ResourcesCompat;
 
 import com.yydcdut.rxmarkdown.RxMDConfiguration;
+import com.yydcdut.rxmarkdown.RxMDConfiguration.Builder;
 
 import it.niedermann.owncloud.notes.R;
 
@@ -19,7 +20,7 @@ public class MarkDownUtil {
      * @param context Context
      * @return RxMDConfiguration
      */
-    public static RxMDConfiguration getMarkDownConfiguration(Context context) {
+    public static Builder getMarkDownConfiguration(Context context) {
         return new RxMDConfiguration.Builder(context)
                 .setHeader2RelativeSize(1.35f)
                 .setHeader3RelativeSize(1.25f)
@@ -27,7 +28,6 @@ public class MarkDownUtil {
                 .setHeader5RelativeSize(1.1f)
                 .setHeader6RelativeSize(1.05f)
                 .setHorizontalRulesHeight(2)
-                .setLinkFontColor(ResourcesCompat.getColor(context.getResources(), R.color.primary, null))
-                .build();
+                .setLinkFontColor(ResourcesCompat.getColor(context.getResources(), R.color.primary, null));
     }
 }


### PR DESCRIPTION
This is a basic implementation of v0.1.2 of RxMarkdown using the Reactive X way.

It also implements toggling checkboxes from within the view mode.

problems left:

- [ ] We have to wait for v0.1.3 because of https://github.com/yydcdut/RxMarkdown/issues/50
- [ ] After toggling a checkbox the content is displayed as plain text and does not get processed anymore (unti switching to edit mode and back to view mode)
- [ ] toggling the last checkbox (last line) causes the last letter of this line to disappear. Not sure yet if this is a bug of RxMarkdown or a result of wrong usage.

I did not have any success implementing this without Reactive X (the checkbox-listener was not called - maybe a bug, too).