### PR TITLE
Introduce yellow favorite stars instead of outline

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -197,7 +197,7 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
 
     private void setupNavigationList(final String selectedItem) {
         itemRecent = new NavigationAdapter.NavigationItem(ADAPTER_KEY_RECENT, getString(R.string.label_all_notes), null, R.drawable.ic_access_time_grey600_24dp);
-        itemFavorites = new NavigationAdapter.NavigationItem(ADAPTER_KEY_STARRED, getString(R.string.label_favorites), null, R.drawable.ic_star_grey600_24dp);
+        itemFavorites = new NavigationAdapter.NavigationItem(ADAPTER_KEY_STARRED, getString(R.string.label_favorites), null, R.drawable.ic_star_yellow_24dp);
         adapterCategories = new NavigationAdapter(new NavigationAdapter.ClickListener() {
             @Override
             public void onItemClick(NavigationAdapter.NavigationItem item) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/appwidget/NoteListWidgetConfiguration.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/appwidget/NoteListWidgetConfiguration.java
@@ -12,7 +12,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
-import android.view.View;
 import android.widget.Toast;
 
 import java.util.ArrayList;
@@ -68,7 +67,7 @@ public class NoteListWidgetConfiguration extends AppCompatActivity {
         itemFavorites = new NavigationAdapter.NavigationItem(NotesListViewActivity.ADAPTER_KEY_STARRED,
                                                             getString(R.string.label_favorites),
                                                             null,
-                                                            R.drawable.ic_star_grey600_24dp);
+                                                            R.drawable.ic_star_yellow_24dp);
         RecyclerView recyclerView;
         RecyclerView.LayoutManager layoutManager;
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/ItemAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/ItemAdapter.java
@@ -105,7 +105,7 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             nvHolder.noteCategory.setText(Html.fromHtml(note.getCategory()));
             nvHolder.noteExcerpt.setText(Html.fromHtml(note.getExcerpt()));
             nvHolder.noteStatus.setVisibility(DBStatus.VOID.equals(note.getStatus()) ? View.INVISIBLE : View.VISIBLE);
-            nvHolder.noteFavorite.setImageResource(note.isFavorite() ? R.drawable.ic_star_grey600_24dp : R.drawable.ic_star_border_grey600_24dp);
+            nvHolder.noteFavorite.setImageResource(note.isFavorite() ? R.drawable.ic_star_yellow_24dp : R.drawable.ic_star_grey_ccc_24dp);
             nvHolder.noteFavorite.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {

--- a/app/src/main/res/drawable/ic_star_border_grey600_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_border_grey600_24dp.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#757575" android:viewportHeight="24.0"
-    android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF757575" android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_star_grey600_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_grey600_24dp.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#757575" android:viewportHeight="24.0"
-    android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF757575" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_star_grey_ccc_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_grey_ccc_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#cccccc" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFcccccc" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_star_yellow_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_yellow_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFCC00"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF757575" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_notes_list_note_item.xml
+++ b/app/src/main/res/layout/fragment_notes_list_note_item.xml
@@ -12,8 +12,8 @@
         android:layout_gravity="center_vertical"
         android:layout_marginLeft="@dimen/button_padding"
         android:layout_marginStart="@dimen/button_padding"
-        android:contentDescription="@string/menu_delete"
-        android:src="@drawable/ic_star_white_24dp" />
+        android:contentDescription="@string/menu_favorite"
+        android:src="@drawable/ic_star_yellow_24dp" />
 
     <ImageView
         android:id="@+id/noteDeleteRight"

--- a/app/src/main/res/layout/widget_entry.xml
+++ b/app/src/main/res/layout/widget_entry.xml
@@ -16,7 +16,7 @@
         android:paddingLeft="@dimen/widget_note_list_inner_padding"
         android:paddingEnd="@dimen/widget_note_list_outer_padding"
         android:paddingRight="@dimen/widget_note_list_outer_padding"
-        android:src="@drawable/ic_star_grey600_24dp"
+        android:src="@drawable/ic_star_yellow_24dp"
         android:contentDescription="@string/widget_entry_fav_contentDescription" />
 
     <TextView


### PR DESCRIPTION
like @jancborchardt and @mario suggested:

- Instead of full grey stars use full yellow stars
- Instead of border grey stars use full grey stars

The changes apply to the widgets and the NotesListView but *not* to the Edit/View-Mode of a single note and *not* to the sidebar, where simple mono color icons look prettier imho.

![device-2018-08-23-095707](https://user-images.githubusercontent.com/4741199/44512509-1b2f9b00-a6bb-11e8-8852-4be23849ae74.png)
