### PR TITLE
#398 Check the URL (and draw the check) only on blur

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
@@ -76,6 +76,13 @@ public class SettingsActivity extends AppCompatActivity {
             }
         }
 
+        field_url.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                new URLValidatorAsyncTask().execute(field_url.getText().toString());
+            }
+        });
+
         field_url.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
@@ -91,7 +98,6 @@ public class SettingsActivity extends AppCompatActivity {
                 if (!url.startsWith("http://") && !url.startsWith("https://")) {
                     url = "https://" + url;
                 }
-                new URLValidatorAsyncTask().execute(url);
 
                 if (NotesClientUtil.isHttp(url)) {
                     urlWarnHttp.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Checking the URL on every text change can lead to privacy issues (e.g. if a subdomain is also an existing domain and a request is done to this domain).