### PR TITLE
Fixes for the note list widget

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/appwidget/NoteListWidgetFactory.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/appwidget/NoteListWidgetFactory.java
@@ -57,6 +57,9 @@ public class NoteListWidgetFactory implements RemoteViewsService.RemoteViewsFact
                 }
                 break;
         }
+
+        AppWidgetManager awm = AppWidgetManager.getInstance(context);
+        awm.updateAppWidget(appWidgetId, views);
     }
 
     @Override

--- a/app/src/main/res/layout/widget_note_list.xml
+++ b/app/src/main/res/layout/widget_note_list.xml
@@ -29,7 +29,7 @@
 
         <TextView
             android:id="@+id/widget_note_list_title_tv"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:textColor="@color/white"
             android:textStyle="bold"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -22,8 +22,8 @@
     <dimen name="widget_note_list_header_height">36dp</dimen>
     <dimen name="widget_note_list_icon_width">30dp</dimen>
 
-    <dimen name="widget_note_list_outer_padding">8dp</dimen>
-    <dimen name="widget_note_list_inner_padding">0dp</dimen>
+    <dimen name="widget_note_list_outer_padding">4dp</dimen>
+    <dimen name="widget_note_list_inner_padding">4dp</dimen>
 
     <dimen name="widget_note_list_fav_icon_width">26dp</dimen>
     <dimen name="widget_note_list_fav_icon_height">20dp</dimen>


### PR DESCRIPTION
Fixes in the note list widget for a) alignment of the header app icon, b) alignment of the favourite stars next to the entries and c) the disappearing header text.