### PR TITLE
Permanent fix for white-on-grey widget colours.

### DIFF
--- a/app/src/main/res/layout/widget_entry.xml
+++ b/app/src/main/res/layout/widget_entry.xml
@@ -30,7 +30,7 @@
         android:layout_gravity="center_vertical"
         android:gravity="center_vertical"
         android:layout_weight="1"
-        android:textColor="@color/black"
+        android:textColor="@color/widget_fg_default"
         android:lines="1"
         android:ellipsize="end" />
 

--- a/app/src/main/res/layout/widget_note_list.xml
+++ b/app/src/main/res/layout/widget_note_list.xml
@@ -31,7 +31,7 @@
             android:id="@+id/widget_note_list_title_tv"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:textColor="@color/white"
+            android:textColor="@color/widget_fg_contrast"
             android:textStyle="bold"
             android:textSize="18sp"
             android:layout_toRightOf="@id/widget_note_header_icon"

--- a/app/src/main/res/layout/widget_single_note_content.xml
+++ b/app/src/main/res/layout/widget_single_note_content.xml
@@ -3,4 +3,4 @@
     android:id="@+id/single_note_content_tv"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:textColor="@color/black" />
+    android:textColor="@color/widget_fg_default" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,6 +24,6 @@
     <color name="category_background">#FFF</color>
     <color name="category_border">@color/primary</color>
 
-    <color name="black">#000000</color>
-    <color name="white">#ffffff</color>
+    <color name="widget_fg_default">#000000</color>
+    <color name="widget_fg_contrast">#ffffff</color>
 </resources>


### PR DESCRIPTION
This is the best I can do because I can't reliably replicate the problem. It seems as though DayNight mode being set to night affects the widget's colours but it should do, and it's not documented, so this is how I've gotten around it. There's no night/colors.xml entries so the colours should not change. If acceptable it closes #428.