### PR TITLE
fix background for code in dark mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.jakewharton:butterknife:10.1.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
 
-    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation "com.google.android.material:material:1.0.0"
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
@@ -136,7 +136,7 @@ public class NoteEditFragment extends BaseNoteFragment {
             editContent.setEnabled(true);
 
             RxMarkdown.live(editContent)
-                    .config(MarkDownUtil.getMarkDownConfiguration(getActivity().getApplicationContext()).build())
+                    .config(MarkDownUtil.getMarkDownConfiguration(editContent.getContext()).build())
                     .factory(EditFactory.create())
                     .intoObservable()
                     .subscribe(new Subscriber<CharSequence>() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
@@ -63,7 +63,7 @@ public class NotePreviewFragment extends BaseNoteFragment {
 
         RxMarkdown.with(content, getActivity())
                 .config(
-                        MarkDownUtil.getMarkDownConfiguration(getActivity().getApplicationContext())
+                        MarkDownUtil.getMarkDownConfiguration(noteContent.getContext())
                                 /*.setOnTodoClickCallback(new OnTodoClickCallback() {
                                         @Override
                                         public CharSequence onTodoClicked(View view, String line, int lineNumber) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/MarkDownUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/MarkDownUtil.java
@@ -1,6 +1,8 @@
 package it.niedermann.owncloud.notes.util;
 
 import android.content.Context;
+
+import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 
 import com.yydcdut.rxmarkdown.RxMDConfiguration;
@@ -22,14 +24,15 @@ public class MarkDownUtil {
      */
     public static Builder getMarkDownConfiguration(Context context) {
         return new RxMDConfiguration.Builder(context)
-                .setUnOrderListColor(ResourcesCompat.getColor(context.getResources(), R.color.fg_default, null))
+                .setUnOrderListColor(ContextCompat.getColor(context, R.color.fg_default))
+                .setCodeBgColor(ContextCompat.getColor(context, R.color.fg_default_high))
                 .setHeader2RelativeSize(1.35f)
                 .setHeader3RelativeSize(1.25f)
                 .setHeader4RelativeSize(1.15f)
                 .setHeader5RelativeSize(1.1f)
                 .setHeader6RelativeSize(1.05f)
                 .setHorizontalRulesHeight(2)
-                .setLinkFontColor(ResourcesCompat.getColor(context.getResources(), R.color.primary, null));
+                .setLinkFontColor(ContextCompat.getColor(context, R.color.primary));
     }
 
     public static Builder getMarkDownConfiguration(Context context, Boolean darkTheme) {


### PR DESCRIPTION
The background-color for code elements was the same in dark mode and light mode. Therefore, in dark mode, code elements are not easy to read. With this PR, the chosen colors do respect the current theme and use a much darker background color in dark mode.

## Before
![Screenshot](https://user-images.githubusercontent.com/6277619/64646873-31b8a980-d418-11e9-989c-c863146046f7.png)

## After
![Screenshot](https://user-images.githubusercontent.com/6277619/64646831-1d74ac80-d418-11e9-819b-20b7eac0c271.png)
