### PR TITLE
Skip dropping automatic indices

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/util/DatabaseIndexUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/DatabaseIndexUtil.java
@@ -27,11 +27,14 @@ public class DatabaseIndexUtil {
     }
 
     public static void dropIndexes(@NonNull SQLiteDatabase db) {
-        Cursor c = db.query("sqlite_master", new String[]{"name"}, "type=?", new String[]{"index"}, null, null, null);
-        while (c.moveToNext()) {
-            Log.v(TAG, "Deleting database index: DROP INDEX " + c.getString(0));
-            db.execSQL("DROP INDEX " + c.getString(0));
+        try (Cursor c = db.query("sqlite_master", new String[]{"name", "sql"}, "type=?", new String[]{"index"}, null, null, null)) {
+            while (c.moveToNext()) {
+                // Skip automatic indexes which we can't drop manually
+                if (c.getString(1) != null) {
+                    Log.v(TAG, "Deleting database index: DROP INDEX " + c.getString(0));
+                    db.execSQL("DROP INDEX " + c.getString(0));
+                }
+            }
         }
-        c.close();
     }
 }


### PR DESCRIPTION
They cannot be dropped manually:
`index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped`

> For automatically created indices (used to implement the PRIMARY KEY or UNIQUE constraints) the sql field is NULL.

From https://sqlite.org/faq.html#q7

Can be reproduced by just upgrading to 2.0.0 (without login).

While at it I used try-with-resources to automatically close the cursor.