### PR TITLE
#643 Empty state is shown even if there are notes

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -20,6 +20,7 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -130,6 +131,8 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
     RecyclerView listView;
     @BindView(R.id.empty_content_view)
     RelativeLayout emptyContentView;
+    @BindView(R.id.progress_circular)
+    ProgressBar progressBar;
 
     private ActionBarDrawerToggle drawerToggle;
     private ItemAdapter adapter = null;
@@ -640,6 +643,8 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
             adapter.removeAll();
             return;
         }
+        emptyContentView.setVisibility(View.GONE);
+        progressBar.setVisibility(View.VISIBLE);
         fabCreate.show();
         String subtitle;
         if (navigationSelection.category != null) {
@@ -662,6 +667,7 @@ public class NotesListViewActivity extends AppCompatActivity implements ItemAdap
         LoadNotesListTask.NotesLoadedListener callback = (List<Item> notes, boolean showCategory) -> {
             adapter.setShowCategory(showCategory);
             adapter.setItemList(notes);
+            progressBar.setVisibility(View.GONE);
             if(notes.size() > 0) {
                 emptyContentView.setVisibility(View.GONE);
             } else {

--- a/app/src/main/res/layout/activity_notes_list_view.xml
+++ b/app/src/main/res/layout/activity_notes_list_view.xml
@@ -34,7 +34,8 @@
                 <RelativeLayout
                     android:id="@+id/empty_content_view"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                    android:layout_height="match_parent"
+                    android:visibility="gone">
 
                     <ImageView
                         android:layout_width="wrap_content"
@@ -63,8 +64,13 @@
                         android:layout_centerHorizontal="true"
                         android:layout_marginTop="20dp"
                         android:text="@string/no_notes_yet_description" />
-
                 </RelativeLayout>
+
+                <ProgressBar
+                    android:id="@+id/progress_circular"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"/>
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recycler_view"


### PR DESCRIPTION
Fix #643 

This should display a circular progress bar while the notes list is loading and then either display the list or the empty content view.

@korelstar please review