### PR TITLE
Grammar for error message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,7 @@
     <string name="error_json">is the Notes app activated on the server?</string>
     <string name="error_no_network">no network connection</string>
     <string name="error_files_app">do you have installed the files app?</string>
-    <string name="error_unknown">an unknown error happened.</string>
+    <string name="error_unknown">An unknown error has occurred</string>
 
     <!-- Snackbar Actions -->
 


### PR DESCRIPTION
Improved grammar for error message.

That string is used many times in other nextcloud apps.

Signed-off-by: rakekniven <mark.ziegler@rakekniven.de>