### PR TITLE
Added option to not delete notes on swipe

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -43,7 +43,7 @@
     <string name="settings_font_title">Carattere a spaziatura fissa</string>
     <string name="settings_font_size">Dimensiine carattere</string>
     <string name="settings_wifi_only">Sincronizza solo con Wi-Fi</string>
-
+    <string name="settings_swipe_delete">Cancella nota con swipe</string>
     <!-- Certificates -->
 
     <!-- Network -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="settings_font_title">Monospace font</string>
     <string name="settings_font_size">Font size</string>
     <string name="settings_wifi_only">Sync only on Wi-Fi</string>
+    <string name="settings_swipe_delete">Delete note on swipe</string>
 
     <!-- Certificates -->
 
@@ -112,6 +113,7 @@
     <string name="pref_key_font_size" translatable="false">fontSize</string>
     <string name="pref_key_wifi_only" translatable="false">wifiOnly</string>
     <string name="pref_key_last_note_mode" translatable="false">lastNoteMode</string>
+    <string name="pref_key_swipe_delete" translatable="false">swipeDelete</string>
     <string name="pref_value_mode_edit" translatable="false">edit</string>
     <string name="pref_value_mode_preview" translatable="false">preview</string>
     <string name="pref_value_mode_last" translatable="false">last</string>
@@ -121,6 +123,7 @@
     <string name="pref_value_theme_light">Light</string>
     <string name="pref_value_font_normal">Normal</string>
     <string name="pref_value_wifi_and_mobile">Sync on Wi-Fi and mobile data</string>
+    <string name="pref_value_swipe_delete_enabled">Enable note delete on swipe</string>
     <string name="simple_error">Error</string>
     <string name="simple_close">Close</string>
     <string name="simple_copy">Copy</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -37,4 +37,9 @@
         android:key="@string/pref_key_wifi_only"
         android:title="@string/settings_wifi_only" />
 
+    <SwitchPreference
+        android:defaultValue="true"
+        android:icon="@drawable/ic_delete_grey600_24dp"
+        android:key="@string/pref_key_swipe_delete"
+        android:title="@string/settings_swipe_delete" />
 </PreferenceScreen>


### PR DESCRIPTION
This proposed change resolves an age-old problem., i.e. while scrolling notes a user accidentally deletes one with an unwanted swipe. See #663 #470 #310 #265 #225 #238
This happens way too often (at least to me), and after some damage happened to my real life because of this bug, I decided to take action.

The implemented solution is simple. A new option ("Delete note on swipe") allows the user to opt-out of the ability to delete notes by swiping. By default the option is active, meaning that the app behavior is unchanged. If the user disables the option, the swipe left is disabled (the swipe right to make a note important is not affected).

Given that there is still no integrated trashbin in the app and that it is so difficult to restore a deleted note, and that to some users (see the number of related issues) it happens very often to accidentally delete a note, this solution will make the app safer for a good amount of users.

