### PR TITLE
Fix #538 - text area covers whole screen

### DIFF
--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fillViewport="true"
     android:orientation="vertical"
     tools:context="it.niedermann.owncloud.notes.android.activity.EditNoteActivity">
 
@@ -10,6 +11,7 @@
             android:id="@+id/editContent"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="top"
             android:ems="10"
             android:inputType="textMultiLine|textCapSentences"
             android:padding="16dp"


### PR DESCRIPTION
Fixes #538. The EditText now expands across the entire screen. Scrolling works.

Only tested on Android 10 (OxygenOS).