### PR TITLE
Back button on notes opened from other notes

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/EditNoteActivity.java
@@ -208,11 +208,6 @@ public class EditNoteActivity extends AppCompatActivity implements BaseNoteFragm
     }
 
     @Override
-    public void onBackPressed() {
-        close();
-    }
-
-    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_note_activity, menu);
         return super.onCreateOptionsMenu(menu);

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NotePreviewFragment.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.android.activity.EditNoteActivity;
 import it.niedermann.owncloud.notes.model.LoginStatus;
 import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
 import it.niedermann.owncloud.notes.util.DisplayUtils;
@@ -159,9 +158,12 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment {
                             if (NoteLinksUtils.isNoteLink(link)) {
                                 long noteRemoteId = NoteLinksUtils.extractNoteRemoteId(link);
                                 long noteLocalId = db.getLocalIdByRemoteId(this.note.getAccountId(), noteRemoteId);
-                                Intent intent = new Intent(getActivity().getApplicationContext(), EditNoteActivity.class);
-                                intent.putExtra(EditNoteActivity.PARAM_NOTE_ID, noteLocalId);
-                                startActivity(intent);
+
+                                NotePreviewFragment next = NotePreviewFragment.newInstance(this.note.getAccountId(), noteLocalId);
+                                getActivity().getSupportFragmentManager().beginTransaction()
+                                        .add(((ViewGroup)getView().getParent()).getId(), next)
+                                        .addToBackStack(null)
+                                        .commit();
                             } else {
                                 Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
                                 startActivity(browserIntent);


### PR DESCRIPTION
Intended to fix back button behaviour on notes that were opened from other notes (see #646) as reported in [this comment](https://github.com/stefan-niedermann/nextcloud-notes/issues/623#issuecomment-578415804).

To be honest, I'm not 100% sure what is going on. Just removing the activity close code on `onBackButtonPressed` wasn't enough. Creating new fragments instead of activities seems to fix the issue. Still I'd be happy to have some discussion on the code.

I did some manual testing and didn't notice weird side effects by the changes.