### PR TITLE
#558 Move the cursor to the beginning of the document after entering …

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/NoteEditFragment.java
@@ -143,6 +143,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         textWatcher = new NotesTextWatcher(editContent) {
             @Override
             public void afterTextChanged(final Editable s) {
+                super.afterTextChanged(s);
                 unsavedEdit = true;
                 if (!saveActive) {
                     handler.removeCallbacks(runAutoSave);

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/NotesTextWatcher.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/NotesTextWatcher.java
@@ -1,17 +1,26 @@
 package it.niedermann.owncloud.notes.util;
 
+import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.widget.EditText;
 
 /**
  * Implements auto-continuation for checked-lists
  */
 public abstract class NotesTextWatcher implements TextWatcher {
+
+    private static final String TAG = NotesTextWatcher.class.getCanonicalName();
+
+    private static final String codeBlock = "```";
+
     private static final String uncheckedMinusCheckbox = "- [ ] ";
     private static final String uncheckedStarCheckbox = "* [ ] ";
     private static final String checkedMinusCheckbox = "- [x] ";
     private static final String checkedStarCheckbox = "* [x] ";
     private static final int lengthCheckbox = 6;
+
+    private int resetSelectionTo = -1;
 
     private EditText editText;
 
@@ -26,21 +35,66 @@ public abstract class NotesTextWatcher implements TextWatcher {
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
+        // https://github.com/stefan-niedermann/nextcloud-notes/issues/608
         if (count == 1 && s.charAt(start) == '\n') { // 'Enter' was pressed
-            // Find start of line
-            int startOfLine = start;
-            while (startOfLine > 0 && s.charAt(startOfLine - 1) != '\n') {
-                startOfLine--;
-            }
-            String line = s.subSequence(startOfLine, start).toString();
+            autoContinueCheckboxListsOnEnter(s, start, count);
+        }
+        // https://github.com/stefan-niedermann/nextcloud-notes/issues/558
+        if (s.toString().contains(codeBlock)) {
+            preventCursorJumpToTopWithinCodeBlock(s, start, count);
+        }
+    }
 
-            if (line.equals(uncheckedMinusCheckbox) || line.equals(uncheckedStarCheckbox)) {
-                editText.setSelection(startOfLine + 1);
-                setNewText(new StringBuilder(s).replace(startOfLine, startOfLine + lengthCheckbox + 1, "\n"), startOfLine + 1);
-            } else if(lineStartsWithCheckbox(line, false)) {
-                setNewText(new StringBuilder(s).insert(start + count, uncheckedMinusCheckbox), start + lengthCheckbox + 1);
-            } else if(lineStartsWithCheckbox(line, true)) {
-                setNewText(new StringBuilder(s).insert(start + count, uncheckedStarCheckbox), start + lengthCheckbox + 1);
+    @Override
+    public void afterTextChanged(Editable s) {
+        if (resetSelectionTo >= 0) {
+            Log.v(TAG, "Resetting selection to " + resetSelectionTo);
+            int clone = resetSelectionTo; // Needs a clone because setNewText triggers this method again -> endless loop
+            resetSelectionTo = -1;
+            setNewText(new StringBuilder(s), clone);
+        }
+    }
+
+    private void autoContinueCheckboxListsOnEnter(CharSequence s, int start, int count) {
+        // Find start of line
+        int startOfLine = getStartOfLine(s, start);
+        String line = s.subSequence(startOfLine, start).toString();
+
+        if (line.equals(uncheckedMinusCheckbox) || line.equals(uncheckedStarCheckbox)) {
+            editText.setSelection(startOfLine + 1);
+            setNewText(new StringBuilder(s).replace(startOfLine, startOfLine + lengthCheckbox + 1, "\n"), startOfLine + 1);
+        } else if (lineStartsWithCheckbox(line, false)) {
+            setNewText(new StringBuilder(s).insert(start + count, uncheckedMinusCheckbox), start + lengthCheckbox + 1);
+        } else if (lineStartsWithCheckbox(line, true)) {
+            setNewText(new StringBuilder(s).insert(start + count, uncheckedStarCheckbox), start + lengthCheckbox + 1);
+        }
+    }
+
+    private static int getStartOfLine(CharSequence s, int start) {
+        int startOfLine = start;
+        while (startOfLine > 0 && s.charAt(startOfLine - 1) != '\n') {
+            startOfLine--;
+        }
+        return startOfLine;
+    }
+
+    private void preventCursorJumpToTopWithinCodeBlock(CharSequence s, int start, int count) {
+        // Find start of line
+        int startOfLine = getStartOfLine(s, start);
+        String line = s.subSequence(startOfLine, start).toString();
+        if (line.startsWith(codeBlock)) {
+            // "start" is the direct sibling of the codeBlock
+            if (start - startOfLine == codeBlock.length()) {
+                if (resetSelectionTo == -1) {
+                    resetSelectionTo = editText.getSelectionEnd();
+                    Log.v(TAG, "Entered a character directly behind a codeBlock - prepare selection reset to " + resetSelectionTo);
+                }
+            }
+        } else if (s.subSequence(startOfLine, start + count).toString().startsWith(codeBlock)) {
+            // FIXME If starting codeblock is completed with the third `-character, the application gets an endless loop
+            if (resetSelectionTo == -1) {
+                resetSelectionTo = editText.getSelectionEnd();
+                Log.v(TAG, "One completed a ``-codeBlock with the third `-character - prepare selection reset to " + resetSelectionTo);
             }
         }
     }


### PR DESCRIPTION
…the character

Fixes #558 

- [x] If starting codeblock is completed with the third `-character, the application gets an endless loop

Signed-off-by: stefan-niedermann <info@niedermann.it>