### PR TITLE
Bug fix: 769

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/SearchableBaseNoteFragment.java
@@ -216,6 +216,9 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     }
 
     private static int countOccurrences(String haystack, String needle) {
+        if (haystack == null || haystack.isEmpty() || needle == null || needle.isEmpty()) {
+            return 0;
+        }
         Matcher m = Pattern.compile(needle, Pattern.CASE_INSENSITIVE | Pattern.LITERAL)
                 .matcher(haystack);
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/SearchableBaseNoteFragment.java
@@ -33,6 +33,7 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     private int occurrenceCount = 0;
     private SearchView searchView;
     private String searchQuery = null;
+    private final int delay = 50; // If the search string does not change after $delay ms, then the search task starts.
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
@@ -108,7 +109,6 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
         }
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-            private final int delay = 20; // If the search string does not change after $delay ms, then the search task starts.
             private DelayQueryRunnable delayQueryTask;
             private Handler handler = new Handler();
 
@@ -144,7 +144,8 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
                     handler.removeCallbacksAndMessages(null);
                 }
                 delayQueryTask = new DelayQueryRunnable(newText);
-                handler.postDelayed(delayQueryTask, delay);
+                // If there is only one char in the search pattern, we should start the search immediately.
+                handler.postDelayed(delayQueryTask, newText.length() > 1 ? delay : 0);
             }
 
             class DelayQueryRunnable implements Runnable {

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/fragment/SearchableBaseNoteFragment.java
@@ -17,6 +17,9 @@ import androidx.appcompat.widget.SearchView;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import it.niedermann.owncloud.notes.R;
 
 public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
@@ -213,18 +216,12 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
     }
 
     private static int countOccurrences(String haystack, String needle) {
-        if (haystack == null || haystack.isEmpty() || needle == null || needle.isEmpty()) {
-            return 0;
-        }
-        int lastIndex = 0;
-        int count = 0;
+        Matcher m = Pattern.compile(needle, Pattern.CASE_INSENSITIVE | Pattern.LITERAL)
+                .matcher(haystack);
 
-        while (lastIndex != -1) {
-            lastIndex = haystack.toLowerCase().indexOf(needle.toLowerCase(), lastIndex);
-            if (lastIndex != -1) {
-                count++;
-                lastIndex += needle.length();
-            }
+        int count = 0;
+        while (m.find()) {
+            count++;
         }
         return count;
     }


### PR DESCRIPTION
The main problem is that it costs too much time in the function of countOccurences. The time complexity of java library function indexOf is m*n (m is the length of the pattern and the n is the length of the search string). So that the worst time complexity of countOccurences is O(mn^2), which is too large. Because the main logic is running in the main thread so that the UI will be frozen for a long time. We use a O(m+n) implementation, which will solve this issue.

We have tested both in Huawei P30 pro and AVD. In our test, we create three test notes, the length of which are 28672, 114688 and 229376 separately.
In Huawei P30 pro, with using the indexOf, the average time are 140ms, 520ms, 820ms separately.
In AVD, with using the indexOf, the average time are 1039ms, ANR, ANR.
However, with using our implementation, the average times are significantly reduced.
In Huawei P30 pro, with our implementation, the average time are 1ms, 1ms, 2ms.
In AVD, with our implementation, the average time are 2ms, 9ms, 24ms.