### PR TITLE
Add appWidgetId to PendingIntent's request code

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/appwidget/NoteListWidget.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/appwidget/NoteListWidget.java
@@ -73,7 +73,7 @@ public class NoteListWidget extends AppWidgetProvider {
                     PendingIntent.FLAG_UPDATE_CURRENT);
 
             // Launch create note activity if user taps "+" icon on header
-            PendingIntent newNoteI = PendingIntent.getActivity(context, PENDING_INTENT_NEW_NOTE_RQ,
+            PendingIntent newNoteI = PendingIntent.getActivity(context, (PENDING_INTENT_NEW_NOTE_RQ + appWidgetId),
                     new Intent(context, EditNoteActivity.class).putExtra(PARAM_CATEGORY, new Category(category, displayMode == NLW_DISPLAY_STARRED)),
                     PendingIntent.FLAG_UPDATE_CURRENT);
 


### PR DESCRIPTION
Ensures uniqueness with multiple note list widgets.

Should close #817.

Signed-off-by: Daniel Bailey <daniel.bailey@grappleIT.co.uk>