### PR TITLE
Bug fixed 846:

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/LoadNotesListTask.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/LoadNotesListTask.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -64,7 +65,7 @@ public class LoadNotesListTask extends AsyncTask<Void, Void, List<Item>> {
     private DBNote colorTheNote(DBNote dbNote) {
         if (!TextUtils.isEmpty(searchQuery)) {
             SpannableString spannableString = new SpannableString(dbNote.getTitle());
-            Matcher matcher = Pattern.compile("(" + searchQuery + ")", Pattern.CASE_INSENSITIVE).matcher(spannableString);
+            Matcher matcher = Pattern.compile("(" + Pattern.quote(searchQuery.toString()) + ")", Pattern.CASE_INSENSITIVE).matcher(spannableString);
             while (matcher.find()) {
                 spannableString.setSpan(new ForegroundColorSpan(searchForeground), matcher.start(), matcher.end(), 0);
                 spannableString.setSpan(new BackgroundColorSpan(searchBackground), matcher.start(), matcher.end(), 0);
@@ -73,7 +74,7 @@ public class LoadNotesListTask extends AsyncTask<Void, Void, List<Item>> {
             dbNote.setTitle(Html.toHtml(spannableString));
 
             spannableString = new SpannableString(dbNote.getExcerpt());
-            matcher = Pattern.compile("(" + searchQuery + ")", Pattern.CASE_INSENSITIVE).matcher(spannableString);
+            matcher = Pattern.compile("(" + Pattern.quote(searchQuery.toString()) + ")", Pattern.CASE_INSENSITIVE).matcher(spannableString);
             while (matcher.find()) {
                 spannableString.setSpan(new ForegroundColorSpan(searchForeground), matcher.start(), matcher.end(), 0);
                 spannableString.setSpan(new BackgroundColorSpan(searchBackground), matcher.start(), matcher.end(), 0);

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/LoadNotesListTask.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/LoadNotesListTask.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -65,6 +64,9 @@ public class LoadNotesListTask extends AsyncTask<Void, Void, List<Item>> {
     private DBNote colorTheNote(DBNote dbNote) {
         if (!TextUtils.isEmpty(searchQuery)) {
             SpannableString spannableString = new SpannableString(dbNote.getTitle());
+            // The Pattern.quote method will add \Q to the very beginning of the string and \E to the end of the string
+            // It implies that the string between \Q and \E is a literal string and thus the reserved keyword in such string will be ignored.
+            // See https://stackoverflow.com/questions/15409296/what-is-the-use-of-pattern-quote-method
             Matcher matcher = Pattern.compile("(" + Pattern.quote(searchQuery.toString()) + ")", Pattern.CASE_INSENSITIVE).matcher(spannableString);
             while (matcher.find()) {
                 spannableString.setSpan(new ForegroundColorSpan(searchForeground), matcher.start(), matcher.end(), 0);


### PR DESCRIPTION
Use Pattern.quote method to force that the searchQuery is a literal string instead of the reserved keyword in regex

I checked the other method which also uses regex. But it is amazing that it seems that they use some other ways to avoid this conflict.

The modification is very small, so I do not write the unit test (because i do not think it needs)

Please do not hesitate to contact me if there is any problem.