### PR TITLE
Tweak toolbar design

### DIFF
--- a/app/src/main/res/layout/activity_notes_list_view.xml
+++ b/app/src/main/res/layout/activity_notes_list_view.xml
@@ -37,12 +37,12 @@
                 android:id="@+id/home_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/spacer_1x"
-                android:layout_marginTop="@dimen/design_appbar_elevation"
-                android:layout_marginEnd="@dimen/spacer_1x"
-                android:layout_marginBottom="@dimen/design_appbar_elevation"
+                android:layout_marginStart="@dimen/spacer_2x"
+                android:layout_marginTop="@dimen/spacer_1hx"
+                android:layout_marginEnd="@dimen/spacer_2x"
+                android:layout_marginBottom="@dimen/spacer_1hx"
                 app:cardCornerRadius="@dimen/spacer_1x"
-                app:cardElevation="6dp"
+                app:cardElevation="2dp"
                 app:strokeWidth="0dp">
 
                 <LinearLayout
@@ -55,7 +55,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:background="?attr/selectableItemBackgroundBorderless"
-                        android:paddingStart="@dimen/spacer_1x"
+                        android:paddingStart="@dimen/spacer_2x"
                         android:paddingTop="@dimen/spacer_2x"
                         android:paddingEnd="@dimen/spacer_1x"
                         android:paddingBottom="@dimen/spacer_2x"

--- a/app/src/main/res/layout/activity_notes_list_view.xml
+++ b/app/src/main/res/layout/activity_notes_list_view.xml
@@ -41,6 +41,7 @@
                 android:layout_marginTop="@dimen/spacer_1hx"
                 android:layout_marginEnd="@dimen/spacer_2x"
                 android:layout_marginBottom="@dimen/spacer_1hx"
+                app:cardBackgroundColor="@color/appbar"
                 app:cardCornerRadius="@dimen/spacer_1x"
                 app:cardElevation="2dp"
                 app:strokeWidth="0dp">

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -18,4 +18,6 @@
     <color name="fg_contrast">#000000</color>
 
     <color name="category_background">@color/defaultBrand</color>
+
+    <color name="appbar">#1e1e1e</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,6 +29,8 @@
     <color name="category_background">@color/bg_normal</color>
     <color name="category_border">@color/defaultBrand</color>
 
+    <color name="appbar">@android:color/white</color>
+
     <!-- Dark Theme -->
     <!-- Defined here until appwidgets can use night/colors -->
     <color name="fg_default_dark_theme">#eeeeee</color>


### PR DESCRIPTION
This PR tweaks the toolbar in two respects:

The reason being to make it not only more consistent with the files app, but also visually nicer (though the new design was a far bigger jump than these tweaks!).

### 1) Align padddings and elevation

with the files app.

The lesser elevation is especially noticeable in light mode. Having less elevation looks more modern, more like what we see in many of Google's apps implementing Material 2.

Secondly, it adds more margin before and after the card - again, the same values that the files app uses. It also sets the margin to the left of the hamburger to the same value as above and below it.
I conciously did not align the top and bottom margins of the cardview with the files app, so that the height can stay at `?attr/actionBarSize`.

This essentially trades off two design points: giving the toolbar more space (not so squeezed to the screen edge) and having symmetries around the hamburger **versus** aligning the hamburger with the star icons in the recycler. I would argue that the overall impression is nevertheless a cleaner one after these changes. (Especially the hamburger squeezed towards the left edge of the card looked weird.)

| Before  | After  |
|---|---|
|  <img src=https://user-images.githubusercontent.com/33295590/84806957-ccc55c00-b006-11ea-9164-559dd11f8c39.jpg width=200> | <img src=https://user-images.githubusercontent.com/33295590/84806950-cc2cc580-b006-11ea-9be9-bb388448f5dd.jpg width=200>  |

### 2) Darken colour of toolbar in darkmode

For that, it uses the same colour as the files app. The old (default) cardColor was a little too bright.

<img src=https://user-images.githubusercontent.com/33295590/84807254-46f5e080-b007-11ea-912c-82f13d8acae4.jpg width=200>
