### PR TITLE
Decrease card elevation and add background color

### DIFF
--- a/app/src/main/res/layout/activity_notes_list_view.xml
+++ b/app/src/main/res/layout/activity_notes_list_view.xml
@@ -41,8 +41,9 @@
                 android:layout_marginTop="@dimen/design_appbar_elevation"
                 android:layout_marginEnd="@dimen/spacer_1x"
                 android:layout_marginBottom="@dimen/design_appbar_elevation"
+                app:cardBackgroundColor="@color/appbar"
                 app:cardCornerRadius="@dimen/spacer_1x"
-                app:cardElevation="6dp"
+                app:cardElevation="2dp"
                 app:strokeWidth="0dp">
 
                 <LinearLayout

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -17,5 +17,7 @@
     <color name="fg_default_high">#757575</color>
     <color name="fg_contrast">#000000</color>
 
+    <color name="appbar">#1e1e1e</color>
+
     <color name="category_background">@color/defaultBrand</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,6 +29,8 @@
     <color name="category_background">@color/bg_normal</color>
     <color name="category_border">@color/defaultBrand</color>
 
+    <color name="appbar">@android:color/white</color>
+
     <!-- Dark Theme -->
     <!-- Defined here until appwidgets can use night/colors -->
     <color name="fg_default_dark_theme">#eeeeee</color>


### PR DESCRIPTION
Replaces the easy parts of #872.

Curious thing with the files app though - it defines `app:background="@color/appbar"` in `toolbar_standard.xml` but I don't think it actually uses that when build, because `com.google.android.material.card.MaterialCardView` has no attribute `background`. Will need to raise that there...