### PR TITLE
Improve navdrawer items design

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/model/NavigationAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/NavigationAdapter.java
@@ -111,12 +111,13 @@ public class NavigationAdapter extends RecyclerView.Adapter<NavigationAdapter.Vi
             } else {
                 icon.setVisibility(View.GONE);
             }
-            view.setBackgroundColor(isSelected ? view.getResources().getColor(R.color.bg_highlighted) : Color.TRANSPARENT);
             int textColor = isSelected ? mainColor : view.getResources().getColor(R.color.fg_default);
 
             name.setTextColor(textColor);
             count.setTextColor(textColor);
             icon.setColorFilter(isSelected ? textColor : 0);
+
+            view.setSelected(isSelected);
         }
     }
 

--- a/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?colorControlHighlight">
+
+    <item
+        android:id="@android:id/mask"
+        android:left="@dimen/spacer_1x"
+        android:right="@dimen/spacer_1x"
+        android:top="@dimen/spacer_1hx"
+        android:bottom="@dimen/spacer_1hx">
+
+        <shape android:shape="rectangle">
+            <!-- value of color is irrelevant, but solid needs to be defined for mask to work -->
+            <solid android:color="@color/bg_highlighted" />
+            <corners android:radius="@dimen/spacer_1hx" />
+        </shape>
+    </item>
+
+    <item
+        android:left="@dimen/spacer_1x"
+        android:right="@dimen/spacer_1x"
+        android:top="@dimen/spacer_1hx"
+        android:bottom="@dimen/spacer_1hx">
+
+        <selector>
+            <item android:state_selected="true">
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/spacer_1hx" />
+                    <solid android:color="@color/bg_highlighted" />
+                </shape>
+            </item>
+
+            <item>
+                <shape android:shape="rectangle">
+                    <corners android:radius="@dimen/spacer_1hx" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+
+</ripple>

--- a/app/src/main/res/drawable/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable/bg_navdrawer_item.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:left="@dimen/spacer_1x"
+    android:right="@dimen/spacer_1x"
+    android:top="@dimen/spacer_1hx"
+    android:bottom="@dimen/spacer_1hx">
+
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/bg_highlighted" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle"/>
+    </item>
+
+</selector>

--- a/app/src/main/res/layout/item_navigation.xml
+++ b/app/src/main/res/layout/item_navigation.xml
@@ -3,9 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@drawable/bg_navdrawer_item"
     android:gravity="center_vertical"
+    android:paddingTop="@dimen/spacer_1hx"
+    android:paddingBottom="@dimen/spacer_1hx"
     android:paddingStart="@dimen/spacer_1x"
-    android:paddingEnd="@dimen/spacer_1x">
+    android:paddingEnd="@dimen/spacer_2x">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/navigationItemIcon"


### PR DESCRIPTION
On API >=21:
- make design of selected item similar to the files app (not pixel-similar, but similar)
- add touch states :innocent: 

On API 17-20 the height slightly increased as well (needed to make it look good on >= 21), but otherwise the look is preserved.

|  API 17-20 | API >=21  |
|---|---|
|  <img src=https://user-images.githubusercontent.com/33295590/84876820-f70b2e00-b087-11ea-94f0-d65df8fc91fc.jpg width=200> | <img src=https://user-images.githubusercontent.com/33295590/84876829-fa061e80-b087-11ea-8ffd-79ddf996e8c4.jpg width=200>  |
