### PR TITLE
883 move the fav star in grid mode

### DIFF
--- a/app/src/main/res/layout/item_notes_list_note_item_grid.xml
+++ b/app/src/main/res/layout/item_notes_list_note_item_grid.xml
@@ -52,27 +52,6 @@
             android:orientation="horizontal">
 
             <FrameLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1">
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/noteCategory"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/spacer_2x"
-                    android:layout_marginEnd="0dp"
-                    android:ellipsize="middle"
-                    android:textColor="?android:textColorPrimary"
-                    android:textSize="@dimen/secondary_font_size"
-                    app:chipBackgroundColor="@color/primary"
-                    app:chipStrokeColor="@color/defaultBrand"
-                    app:chipStrokeWidth="1dp"
-                    tools:maxLength="50"
-                    tools:text="@tools:sample/lorem/random" />
-            </FrameLayout>
-
-            <FrameLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content">
 
@@ -94,6 +73,28 @@
                     android:layout_marginEnd="4dp"
                     android:baseline="14dp"
                     app:srcCompat="@drawable/ic_sync_blue_18dp" />
+            </FrameLayout>
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/noteCategory"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:layout_marginStart="0dp"
+                    android:layout_marginEnd="@dimen/spacer_2x"
+                    android:ellipsize="middle"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="@dimen/secondary_font_size"
+                    app:chipBackgroundColor="@color/primary"
+                    app:chipStrokeColor="@color/defaultBrand"
+                    app:chipStrokeWidth="1dp"
+                    tools:maxLength="50"
+                    tools:text="@tools:sample/lorem/random" />
             </FrameLayout>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_notes_list_note_item_grid_only_title.xml
+++ b/app/src/main/res/layout/item_notes_list_note_item_grid_only_title.xml
@@ -16,25 +16,10 @@
         android:orientation="horizontal"
         android:paddingBottom="@dimen/spacer_1x">
 
-        <TextView
-            android:id="@+id/noteTitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/spacer_2x"
-            android:layout_marginTop="@dimen/spacer_2x"
-            android:layout_marginEnd="@dimen/spacer_2x"
-            android:layout_marginBottom="@dimen/spacer_1x"
-            android:layout_weight="1"
-            android:hyphenationFrequency="full"
-            android:textAppearance="?attr/textAppearanceHeadline5"
-            android:textColor="@color/fg_default"
-            tools:maxLength="50"
-            tools:targetApi="m"
-            tools:text="@tools:sample/lorem/random" />
-
         <FrameLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacer_1qx">
 
             <ImageView
                 android:id="@+id/noteFavorite"
@@ -55,5 +40,21 @@
                 android:baseline="14dp"
                 app:srcCompat="@drawable/ic_sync_blue_18dp" />
         </FrameLayout>
+
+        <TextView
+            android:id="@+id/noteTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="0dp"
+            android:layout_marginTop="@dimen/spacer_2x"
+            android:layout_marginEnd="@dimen/spacer_2x"
+            android:layout_marginBottom="@dimen/spacer_1x"
+            android:layout_weight="1"
+            android:hyphenationFrequency="full"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:textColor="@color/fg_default"
+            tools:maxLength="50"
+            tools:targetApi="m"
+            tools:text="@tools:sample/lorem/random" />
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="spacer_1qx">2dp</dimen>
     <dimen name="spacer_1hx">4dp</dimen>
     <dimen name="spacer_1x">8dp</dimen>
     <dimen name="spacer_2x">16dp</dimen>


### PR DESCRIPTION
Fix #883 

(Alternatively keep the category directly next to the star...?)

![grafik](https://user-images.githubusercontent.com/4741199/85202075-334ac280-b304-11ea-9f2b-00605ef6f8cb.png)
