### PR TITLE
Remove padding between navigation items again

### DIFF
--- a/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable-v21/bg_navdrawer_item.xml
@@ -5,9 +5,7 @@
     <item
         android:id="@android:id/mask"
         android:left="@dimen/spacer_1x"
-        android:right="@dimen/spacer_1x"
-        android:top="@dimen/spacer_1hx"
-        android:bottom="@dimen/spacer_1hx">
+        android:right="@dimen/spacer_1x">
 
         <shape android:shape="rectangle">
             <!-- value of color is irrelevant, but solid needs to be defined for mask to work -->
@@ -18,9 +16,7 @@
 
     <item
         android:left="@dimen/spacer_1x"
-        android:right="@dimen/spacer_1x"
-        android:top="@dimen/spacer_1hx"
-        android:bottom="@dimen/spacer_1hx">
+        android:right="@dimen/spacer_1x">
 
         <selector>
             <item android:state_selected="true">

--- a/app/src/main/res/drawable/bg_navdrawer_item.xml
+++ b/app/src/main/res/drawable/bg_navdrawer_item.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android"
     android:left="@dimen/spacer_1x"
-    android:right="@dimen/spacer_1x"
-    android:top="@dimen/spacer_1hx"
-    android:bottom="@dimen/spacer_1hx">
+    android:right="@dimen/spacer_1x">
 
     <item android:state_selected="true">
         <shape android:shape="rectangle">

--- a/app/src/main/res/layout/item_navigation.xml
+++ b/app/src/main/res/layout/item_navigation.xml
@@ -5,8 +5,6 @@
     android:layout_height="wrap_content"
     android:background="@drawable/bg_navdrawer_item"
     android:gravity="center_vertical"
-    android:paddingTop="@dimen/spacer_1hx"
-    android:paddingBottom="@dimen/spacer_1hx"
     android:paddingStart="@dimen/spacer_1x"
     android:paddingEnd="@dimen/spacer_2x">
 


### PR DESCRIPTION
#875 introduced some spacing between the navigation drawer items, so that the touch states would not touch (badumtss) each other.

Turns out that might have been too much - with a lot of categories, that's a lot of wasted space. This removes the upper/lower padding again.