### PR TITLE
Bug fixed: Use getLayoutPosition instead of getAdapterPosition. #994, #988

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/NoteViewHolder.java
@@ -50,8 +50,8 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
 
     @CallSuper
     public void bind(@NonNull DBNote note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
-        itemView.setOnClickListener((view) -> noteClickListener.onNoteClick(getAdapterPosition(), view));
-        itemView.setOnLongClickListener((view) -> noteClickListener.onNoteLongClick(getAdapterPosition(), view));
+        itemView.setOnClickListener((view) -> noteClickListener.onNoteClick(getLayoutPosition(), view));
+        itemView.setOnLongClickListener((view) -> noteClickListener.onNoteLongClick(getLayoutPosition(), view));
     }
 
     protected void bindStatus(AppCompatImageView noteStatus, DBStatus status, int mainColor) {
@@ -106,7 +106,7 @@ public abstract class NoteViewHolder extends RecyclerView.ViewHolder {
 
     protected void bindFavorite(@NonNull ImageView noteFavorite, boolean isFavorite) {
         noteFavorite.setImageResource(isFavorite ? R.drawable.ic_star_yellow_24dp : R.drawable.ic_star_grey_ccc_24dp);
-        noteFavorite.setOnClickListener(view -> noteClickListener.onNoteFavoriteClick(getAdapterPosition(), view));
+        noteFavorite.setOnClickListener(view -> noteClickListener.onNoteFavoriteClick(getLayoutPosition(), view));
     }
 
     protected void bindSearchableContent(@NonNull Context context, @NonNull TextView textView, @Nullable CharSequence searchQuery, @NonNull String content, int mainColor) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/items/list/NotesListViewItemTouchHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/items/list/NotesListViewItemTouchHelper.java
@@ -71,7 +71,7 @@ public class NotesListViewItemTouchHelper extends ItemTouchHelper {
             public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
                 switch (direction) {
                     case ItemTouchHelper.LEFT:
-                        final DBNote dbNoteWithoutContent = (DBNote) adapter.getItem(viewHolder.getAdapterPosition());
+                        final DBNote dbNoteWithoutContent = (DBNote) adapter.getItem(viewHolder.getLayoutPosition());
                         final DBNote dbNote = db.getNote(dbNoteWithoutContent.getAccountId(), dbNoteWithoutContent.getId());
                         db.deleteNoteAndSync(ssoAccount, dbNote.getId());
                         adapter.remove(dbNote);
@@ -92,7 +92,7 @@ public class NotesListViewItemTouchHelper extends ItemTouchHelper {
                         }
                         break;
                     case ItemTouchHelper.RIGHT:
-                        final DBNote adapterNote = (DBNote) adapter.getItem(viewHolder.getAdapterPosition());
+                        final DBNote adapterNote = (DBNote) adapter.getItem(viewHolder.getLayoutPosition());
                         db.toggleFavorite(ssoAccount, adapterNote, syncCallBack);
                         refreshLists.run();
                         break;


### PR DESCRIPTION
This pull request is used to fix the bugs of #994 and #988.

**The reason of the bugs**
These bugs are both because of the same reason: `getAdapterPosition()` will return `NO_POSITION`, which is -1, to cause the ArrayIndexOutOfBoundsException.

From the comments of `getAdapterPosition()`, we can know that when the layout under re-render or re-calculate, this method will return -1.
During the two layout life-circle, which is an inconsistency less than 16ms, if `getAdapterPosition()` is called, it will return -1.
This leads to two phenomena

1. ArrayIndexOutOfBoundsException with the position being -1.
2. These tricky issues being difficult to reproduce because it is very hard to call this method in such a short time.

**How to reproduce the bugs**
In order to reproduce this bug, I have two possible plans:

1. Use Monkey or some other tools that can click the screen in a very short time.
2. Force the layout to update and then immediately call `getAdapterPosition()`

For me, I use the second plan to reproduce it.
In order to reproduce it, I update the method `onBindViewHolder(RecyclerView.ViewHolder, int)`  in `it.niedermann.owncloud.notes.main.items.ItemAdapter` and `bind(DBNote, boolean, int, int, CharSequence)` in `it.niedermann.owncloud.notes.main.items.NoteViewHolder` as follows:

```java
public void onBindViewHolder(@NonNull final RecyclerView.ViewHolder holder, int position) {
    switch (getItemViewType(position)) {
        case TYPE_SECTION: {
            ((SectionViewHolder) holder).bind((SectionItem) itemList.get(position));
            break;
        }
        case TYPE_NOTE_WITH_EXCERPT:
        case TYPE_NOTE_WITHOUT_EXCERPT:
        case TYPE_NOTE_ONLY_TITLE: {
            ((NoteViewHolder) holder).bind((DBNote) itemList.get(position), showCategory, mainColor, textColor, searchQuery);
            ((NoteViewHolder) holder).itemView.setOnClickListener((view) -> {
                notifyDataSetChanged();
                noteClickListener.onNoteClick(((NoteViewHolder) holder).getAdapterPosition(), view);
            });
            break;
        }
    }
}
```

```java
public void bind(@NonNull DBNote note, boolean showCategory, int mainColor, int textColor, @Nullable CharSequence searchQuery) {
    itemView.setOnClickListener((view) -> noteClickListener.onNoteClick(getAdapterPosition(), view));
    itemView.setOnLongClickListener((view) -> noteClickListener.onNoteLongClick(getAdapterPosition(), view));
}
```

This modified code does the same thing with before. The only difference is that I call `notifyDataSetChanged()` to force the layout updated before `getAdapterPosition()`.

With this modification, the app crashes each time a note is clicked.


**The difference between getAdapterPosition() and getLayoutPosition()**
These two methods are both new API from Google to replace `getPosition()`. The only difference is that `getAdapterPosition()` will return -1 when the layout is updating, which forces developers to treat such 16ms situation. And `getLayoutPosition()` will return a random position between up-to-date position and not-up-to-date position (the positions before and after update).

This will cause such a problem: If `getLayoutPosition()` is called during this 16ms time, a wrong position may be returned.

However, considering the reality that there are few data changes in a short time, I think it is worthy.