### PR TITLE
Avoid overwriting title for new notes

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesDatabase.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesDatabase.java
@@ -546,7 +546,8 @@ public class NotesDatabase extends AbstractNotesDatabase {
             if (newTitle != null) {
                 title = newTitle;
             } else {
-                if (oldNote.getRemoteId() == 0 || localAccount.getPreferredApiVersion() == null || localAccount.getPreferredApiVersion().compareTo(new ApiVersion("1.0", 0, 0)) < 0) {
+                if ((oldNote.getRemoteId() == 0 || localAccount.getPreferredApiVersion() == null || localAccount.getPreferredApiVersion().compareTo(new ApiVersion("1.0", 0, 0)) < 0)  &&
+                    (oldNote.getTitle().equals(NoteUtil.generateNonEmptyNoteTitle("", getContext())))) {
                     title = NoteUtil.generateNonEmptyNoteTitle(newContent, getContext());
                 } else {
                     title = oldNote.getTitle();


### PR DESCRIPTION
Simple fix to avoid a given title is overwritten. They only whole which still exists is in case the user explicitly wants to use the "default title" as the note title. However I assume an additional flag would be needed to also detect this, but as the likelihood is so low I decided against it.