### PR TITLE
#559 Use emojis for checkboxes in widgets if possible

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/3002000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3002000.txt
@@ -1,0 +1,1 @@
+- ✅ Single note widget displays checkboxes more nicely (#559)

--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -107,7 +107,7 @@ public class MarkdownUtil {
     /**
      * Performs the given {@param map} function for each line which contains a checkbox
      */
-    private static CharSequence runForEachCheckbox(String markdownString, Function<String, String> map) {
+    private static CharSequence runForEachCheckbox(@NonNull String markdownString, @NonNull Function<String, String> map) {
         final String[] lines = markdownString.split("\n");
         boolean isInFencedCodeBlock = false;
         int fencedCodeBlockSigns = 0;

--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -84,12 +84,11 @@ public class MarkdownUtil {
     private static CharSequence replaceCheckboxesWithEmojis(CharSequence parsed) {
         if (checkboxCheckedEmoji != null) {
             // TODO replace
-            TextUtils.replace(parsed,  new String[] {"- [x]"}, new String[] {
-                    checkboxCheckedEmoji
-            });
+            parsed = TextUtils.replace(parsed,  new String[] {"- [x]"}, new String[] {checkboxCheckedEmoji});
         }
         if (checkboxUncheckedEmoji != null) {
             // TODO replace
+            parsed = TextUtils.replace(parsed,  new String[] {"- [ ]"}, new String[] {checkboxUncheckedEmoji});
         }
         return parsed;
     }

--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -91,8 +91,17 @@ public class MarkdownUtil {
 
     @Nullable
     private static String getCheckboxEmoji(boolean checked) {
-        final String[] checkedEmojis = new String[]{"✅", "☑️", "✔️"};
-        final String[] uncheckedEmojis = new String[]{"❌", "\uD83D\uDD32️", "☐️"};
+        final String[] checkedEmojis;
+        final String[] uncheckedEmojis;
+        // Seriously what the fuck, Samsung?
+        // https://emojipedia.org/ballot-box-with-x/
+        if(Build.MANUFACTURER.toLowerCase().contains("samsung")) {
+            checkedEmojis = new String[]{"✅", "☑️", "✔️"};
+            uncheckedEmojis = new String[]{"❌", "\uD83D\uDD32️", "☐️"};
+        } else {
+            checkedEmojis = new String[]{"☒", "✅", "☑️", "✔️"};
+            uncheckedEmojis = new String[]{"☐", "❌", "\uD83D\uDD32️", "☐️"};
+        }
         final Paint paint = new Paint();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             for (String emoji : checked ? checkedEmojis : uncheckedEmojis) {

--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -73,31 +73,24 @@ public class MarkdownUtil {
         final MarkdownProcessor markdownProcessor = new MarkdownProcessor(context);
         markdownProcessor.factory(TextFactory.create());
         final CharSequence parsed = parseCompat(markdownProcessor, content);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return replaceCheckboxesWithEmojis(parsed);
-        } else {
-            return parsed;
-        }
+        return replaceCheckboxesWithEmojis(parsed);
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
     private static CharSequence replaceCheckboxesWithEmojis(CharSequence parsed) {
         if (checkboxCheckedEmoji != null) {
-            // TODO replace
-            parsed = TextUtils.replace(parsed,  new String[] {"- [x]"}, new String[] {checkboxCheckedEmoji});
+            parsed = TextUtils.replace(parsed, new String[]{"- [x]"}, new String[]{checkboxCheckedEmoji});
         }
         if (checkboxUncheckedEmoji != null) {
-            // TODO replace
-            parsed = TextUtils.replace(parsed,  new String[] {"- [ ]"}, new String[] {checkboxUncheckedEmoji});
+            parsed = TextUtils.replace(parsed, new String[]{"- [ ]"}, new String[]{checkboxUncheckedEmoji});
         }
         return parsed;
     }
 
     private static String getCheckboxCheckedEmoji() {
-        final List<String> emojis = Arrays.asList("✅", "☑️", "✔️");
+        final String[] emojis = new String[]{"✅", "☑️", "✔️"};
         final Paint paint = new Paint();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            for(String emoji : emojis) {
+            for (String emoji : emojis) {
                 if (paint.hasGlyph(emoji)) {
                     return emoji;
                 }
@@ -107,10 +100,10 @@ public class MarkdownUtil {
     }
 
     private static String getCheckboxUncheckedEmoji() {
-        final List<String> emojis = Arrays.asList("❌", "\uD83D\uDD32️", "☐️");
+        final String[] emojis = new String[]{"❌", "\uD83D\uDD32️", "☐️"};
         final Paint paint = new Paint();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            for(String emoji : emojis) {
+            for (String emoji : emojis) {
                 if (paint.hasGlyph(emoji)) {
                     return emoji;
                 }

--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -95,7 +95,7 @@ public class MarkdownUtil {
         final String[] uncheckedEmojis;
         // Seriously what the fuck, Samsung?
         // https://emojipedia.org/ballot-box-with-x/
-        if(Build.MANUFACTURER.toLowerCase().contains("samsung")) {
+        if(Build.MANUFACTURER != null && Build.MANUFACTURER.toLowerCase().contains("samsung")) {
             checkedEmojis = new String[]{"✅", "☑️", "✔️"};
             uncheckedEmojis = new String[]{"❌", "\uD83D\uDD32️", "☐️"};
         } else {


### PR DESCRIPTION
For sure not perfect, but a start for #559 (top: old, bottom: new)

![grafik](https://user-images.githubusercontent.com/4741199/110249389-3a8b2c80-7f76-11eb-884e-2cc2928d3074.png)


Only Samsung devices will look like shitty teletubby-stuff because they decided to fuck up the used unicode character and use this instead:

![grafik](https://user-images.githubusercontent.com/4741199/110249484-8938c680-7f76-11eb-9927-a656adefefb4.png)
![grafik](https://user-images.githubusercontent.com/4741199/110249490-8dfd7a80-7f76-11eb-9a52-61b1d66ab38a.png)

That's the reason i will use the ugly :heavy_check_mark: and :x: on those devices :man_shrugging: 