### PR TITLE
enable code shrinking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,9 @@ android {
         }
 
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,17 +1,7 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in C:\Users\stnieder\AppData\Local\Android\sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# don't obfuscate names and preserve line numbers so crash reports stay readable
+-dontobfuscate
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# keep classes needed for single sign on
+-keep class com.nextcloud.android.sso.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,3 +5,14 @@
 
 # keep classes needed for single sign on
 -keep class com.nextcloud.android.sso.** { *; }
+
+# keep serialization info
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    !static !transient <fields>;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
+
+# enable aggressive code shrinking
+android.enableR8.fullMode=true


### PR DESCRIPTION
closes https://github.com/stefan-niedermann/nextcloud-notes/issues/1119

This configuration does not obfuscate the bytecode so stacktraces will still be readable. It does some other useful things like removing unused code.

This reduces the size of the app-fdroid-release.apk from 6.964kB to 5.342kB (-23%). With obfuscation it would be 3.949kB (-43%).

(I understand why somebody would not like to use obfuscation, but fyi Google Play deofuscates stacktraces automatically if you use appbundles and you can also do it manually with the retrace tool if you save the optimization.txt files from release builds)

Btw, thank you for this cool app, I use it a lot. :relaxed:
