### PR TITLE
remove multidex

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,6 @@ android {
         targetSdkVersion 29
         versionCode 3003001
         versionName "3.3.1"
-        multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -83,7 +82,6 @@ dependencies {
     implementation 'androidx.work:work-runtime:2.5.0'
     implementation "com.google.android.material:material:1.3.0"
 
-    implementation 'androidx.multidex:multidex:2.0.1'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     // Testing

--- a/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/NotesApplication.java
@@ -7,14 +7,13 @@ import android.content.res.Configuration;
 import android.util.Log;
 
 import androidx.appcompat.app.AppCompatDelegate;
-import androidx.multidex.MultiDexApplication;
 import androidx.preference.PreferenceManager;
 
 import it.niedermann.owncloud.notes.preferences.DarkModeSetting;
 
 import static androidx.preference.PreferenceManager.getDefaultSharedPreferences;
 
-public class NotesApplication extends MultiDexApplication {
+public class NotesApplication extends Application {
     private static final String TAG = NotesApplication.class.getSimpleName();
 
     private static final long LOCK_TIME = 30_000;

--- a/markdown/build.gradle
+++ b/markdown/build.gradle
@@ -7,12 +7,11 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
-        multiDexEnabled true
     }
 
     compileOptions {
@@ -57,7 +56,6 @@ dependencies {
     implementation "com.yydcdut:markdown-processor:$rxMarkdownVersion"
     implementation "com.yydcdut:rxmarkdown-wrapper:$rxMarkdownVersion"
 
-    implementation 'androidx.multidex:multidex:2.0.1'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
It is not needed when minSdkVersion is 21.

This change improves buildspeed and reduces appsize a little bit.