### PR TITLE
Adds a menu button to remove all selected items from a note

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -13,6 +13,7 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -156,6 +157,36 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
                 binding.editContent.setTypeface(Typeface.MONOSPACE);
             }
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int itemId = item.getItemId();
+        if (itemId == R.id.menu_remove_checked) {
+            /*
+            Example markdown string: "- [x] Item1\n    - [ ] Item2\n- [x] Item3"
+
+            Regex explanation:
+            (?:term1|term2)                 --> (?:...):    do not generate groups and search for term1 OR term2
+
+            ^\s*[-*] \[[xX]\] [^\n]*\n?\r?  --> "^":        Pattern starts from the beginning of the string
+                                                "\s*":      any number of blanks
+                                                "[-*]":     followed by an "-" or an "*"
+                                                "\[[xX]\]": "[x]" or "[X]"
+                                                "[^\n]*":   any character except a new line
+                                                "\n?\r?":   optional newline and carriage return at the end
+                                                ==> removes a checked item in the first line e.g. "- [x] Item1", "* [X] Item2"
+
+            \n\r?\s*[-*] \[[xX]\] [^\n]*    --> "\n\r?":    Pattern starts after a new line with optional carriage return
+                                                "\s*":          any number of blanks
+                                                "[-*]":         followed by an "-" or an "*"
+                                                "\[[xX]\]":     "[x]" or "[X]"
+                                                "[^\n]*":       any characters except a new line
+                                                ==> removes the checked items after the first line "- [x] Item1", "* [X] Item2"
+            */
+            binding.editContent.setMarkdownString(note.getContent().replaceAll("(?:^\\s*[-*] \\[[xX]\\] [^\n]*\n?|\n\r?\\s*[-*] \\[[xX]\\] [^\n]*)", ""));
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NotePreviewFragment.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ScrollView;
@@ -165,6 +166,36 @@ public class NotePreviewFragment extends SearchableBaseNoteFragment implements O
             binding.swiperefreshlayout.setRefreshing(false);
             Toast.makeText(requireContext(), getString(R.string.error_sync, getString(R.string.error_no_network)), Toast.LENGTH_LONG).show();
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int itemId = item.getItemId();
+        if (itemId == R.id.menu_remove_checked) {
+            /*
+            Example markdown string: "- [x] Item1\n    - [ ] Item2\n- [x] Item3"
+
+            Regex explanation:
+            (?:term1|term2)                 --> (?:...):    do not generate groups and search for term1 OR term2
+
+            ^\s*[-*] \[[xX]\] [^\n]*\n?\r?  --> "^":        Pattern starts from the beginning of the string
+                                                "\s*":      any number of blanks
+                                                "[-*]":     followed by an "-" or an "*"
+                                                "\[[xX]\]": "[x]" or "[X]"
+                                                "[^\n]*":   any character except a new line
+                                                "\n?\r?":   optional newline and carriage return at the end
+                                                ==> removes a checked item in the first line e.g. "- [x] Item1", "* [X] Item2"
+
+            \n\r?\s*[-*] \[[xX]\] [^\n]*    --> "\n\r?":    Pattern starts after a new line with optional carriage return
+                                                "\s*":          any number of blanks
+                                                "[-*]":         followed by an "-" or an "*"
+                                                "\[[xX]\]":     "[x]" or "[X]"
+                                                "[^\n]*":       any characters except a new line
+                                                ==> removes the checked items after the first line "- [x] Item1", "* [X] Item2"
+            */
+            binding.singleNoteContent.setMarkdownString(note.getContent().replaceAll("(?:^\\s*[-*] \\[[xX]\\] [^\n]*\n?\r?|\n\r?\\s*[-*] \\[[xX]\\] [^\n]*)", ""));
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/res/menu/menu_note_fragment.xml
+++ b/app/src/main/res/menu/menu_note_fragment.xml
@@ -35,6 +35,11 @@
         android:title="@string/menu_share"
         app:showAsAction="never" />
     <item
+        android:id="@+id/menu_remove_checked"
+        android:orderInCategory="120"
+        android:title="@string/delete_checked_items"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/menu_move"
         android:icon="@drawable/ic_send_grey600_24dp"
         android:orderInCategory="120"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -246,4 +246,5 @@
     <string name="no_account_configured_yet">Bislang kein Konto eingerichtet</string>
     <string name="no_other_accounts">Sie haben bislang keine weiteren Konten eingerichtet.</string>
     <string name="context_based_formatting">Popup für die kontextbasierte Formatierung</string>
+    <string name="delete_checked_items">Markierte Elemente entfernen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,4 +296,5 @@
     <string name="no_account_configured_yet">No account configured yet</string>
     <string name="no_other_accounts">You don\'t have configured any other accounts yet.</string>
     <string name="context_based_formatting">Context based formatting popover</string>
+    <string name="delete_checked_items">Remove selected items</string>
 </resources>


### PR DESCRIPTION
This pr adds an additional button "Remove selected items" to the menu when viewing a note.
When clicked, all selected items (e.g. "- [x] Item1\n", "* [X] Item2\n", ...) are removed from the the markdown string using regular expression and the .replaceAll(..) function.

This would be useful for a to do or shopping list. If you completed multiple tasks, you can remove all of them with one click.

In this commit the string is only set for English and German. 