### PR TITLE
Markdown convert to plain text

### DIFF
--- a/markdown/build.gradle
+++ b/markdown/build.gradle
@@ -61,4 +61,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation group: 'com.youbenzi', name: 'MDTool', version: '1.2.4'
 }

--- a/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
+++ b/markdown/src/main/java/it/niedermann/android/markdown/MarkdownUtil.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.text.HtmlCompat;
 
+import com.youbenzi.mdtool.tool.MDTool;
 import com.yydcdut.markdown.MarkdownProcessor;
 import com.yydcdut.markdown.syntax.text.TextFactory;
 import com.yydcdut.rxmarkdown.RxMarkdown;
@@ -440,22 +441,16 @@ public class MarkdownUtil {
      * @return Plain text string
      */
     @NonNull
+// CS304 issue link: https://github.com/stefan-niedermann/nextcloud-notes/issues/1104
     public static String removeMarkdown(@Nullable String s) {
         if (s == null)
             return "";
         // TODO maybe we can utilize the markwon renderer?
-
-        for (EListType listType : EListType.values()) {
-            s = s.replace(listType.checkboxChecked, "");
-            s = s.replace(listType.checkboxUnchecked, "");
-            s = s.replace(listType.listSymbolWithTrailingSpace, "");
+        String html = MDTool.markdown2Html(s);
+        String htmlRemark = "(<[^<]*?>)|(<[\\s]*?/[^<]*?>)|(<[^<]*?/[\\s]*?>)";
+        if (html == null || html.length() == 0){
+            return "";
         }
-        s = PATTERN_LISTS.matcher(s).replaceAll("");
-        s = PATTERN_HEADINGS.matcher(s).replaceAll("$1");
-        s = PATTERN_HEADING_LINE.matcher(s).replaceAll("");
-        s = PATTERN_EMPHASIS.matcher(s).replaceAll("$2");
-        s = PATTERN_SPACE_1.matcher(s).replaceAll("");
-        s = PATTERN_SPACE_2.matcher(s).replaceAll("");
-        return s;
+        return html.replaceAll(htmlRemark,"");
     }
 }

--- a/markdown/src/test/java/it/niedermann/android/markdown/MarkdownUnitTest.java
+++ b/markdown/src/test/java/it/niedermann/android/markdown/MarkdownUnitTest.java
@@ -1,0 +1,34 @@
+package it.niedermann.android.markdown;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+
+// CS304 issue link: https://github.com/stefan-niedermann/nextcloud-notes/issues/1104
+public class MarkdownUnitTest {
+    @Test
+    public void photoTest() {
+        String md = "![photo](http://127.0.0.1:8090/upload/2021/04/image)";
+        assertEquals("\n",MarkdownUtil.removeMarkdown(md));
+    }
+
+    @Test
+    public void titleTest() {
+        String md = "# title";
+        assertEquals("title\n",MarkdownUtil.removeMarkdown(md));
+    }
+
+    @Test
+    public void spcialFontTest1() {
+        String md = "~~**test**~~  ";
+        assertEquals("test\n",MarkdownUtil.removeMarkdown(md));
+    }
+
+    @Test
+    public void spcialSymbolTest2() {
+        String md = "test - title";
+        assertEquals("test - title\n",MarkdownUtil.removeMarkdown(md));
+    }
+}


### PR DESCRIPTION
Convert markdown to HTML format, then clean HTML tags to get plain text