### PR TITLE
Fix moving note to another account

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/BaseNoteFragment.java
@@ -24,6 +24,7 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.LiveData;
 
 import com.nextcloud.android.sso.exceptions.NextcloudFilesAppAccountNotFoundException;
 import com.nextcloud.android.sso.exceptions.NoCurrentAccountSelectedException;
@@ -240,7 +241,7 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
         } else if (itemId == R.id.menu_move) {
             new Thread(() -> {
                 AccountPickerDialogFragment
-                        .newInstance(new ArrayList<>(), note.getAccountId())
+                        .newInstance(new ArrayList<>(repo.getAccounts()), note.getAccountId())
                         .show(requireActivity().getSupportFragmentManager(), BaseNoteFragment.class.getSimpleName());
             }).start();
             return true;
@@ -372,7 +373,8 @@ public abstract class BaseNoteFragment extends BrandedFragment implements Catego
     }
 
     public void moveNote(Account account) {
-        repo.moveNoteToAnotherAccount(account, note);
+        final LiveData<Note> moveLiveData = repo.moveNoteToAnotherAccount(account, note);
+        moveLiveData.observe(this, (v) -> moveLiveData.removeObservers(this));
         listener.close();
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/main/MainViewModel.java
@@ -488,7 +488,7 @@ public class MainViewModel extends AndroidViewModel {
         });
     }
 
-    public LiveData<Note> moveNoteToAnotherAccount(Account account, Long noteId) {
+    public LiveData<Note> moveNoteToAnotherAccount(Account account, long noteId) {
         return switchMap(repo.getNoteById$(noteId), (note) -> {
             Log.v(TAG, "[moveNoteToAnotherAccount] - note: " + note);
             return repo.moveNoteToAnotherAccount(account, note);

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NotesRepository.java
@@ -67,7 +67,6 @@ import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.O;
 import static androidx.lifecycle.Transformations.distinctUntilChanged;
 import static androidx.lifecycle.Transformations.map;
-import static androidx.lifecycle.Transformations.switchMap;
 import static it.niedermann.owncloud.notes.edit.EditNoteActivity.ACTION_SHORTCUT;
 import static it.niedermann.owncloud.notes.shared.util.NoteUtil.generateNoteExcerpt;
 import static it.niedermann.owncloud.notes.widget.notelist.NoteListWidget.updateNoteListWidgets;
@@ -402,14 +401,12 @@ public class NotesRepository {
 
     @MainThread
     public LiveData<Note> moveNoteToAnotherAccount(Account account, @NonNull Note note) {
-        return switchMap(distinctUntilChanged(db.getNoteDao().getContent$(note.getId())), (content) -> {
-            final Note fullNote = new Note(null, note.getModified(), note.getTitle(), content, note.getCategory(), note.getFavorite(), null);
-            deleteNoteAndSync(account, note.getId());
-            return map(addNoteAndSync(account, fullNote), (createdNote) -> {
-                db.getNoteDao().updateStatus(createdNote.getId(), DBStatus.LOCAL_EDITED);
-                createdNote.setStatus(DBStatus.LOCAL_EDITED);
-                return createdNote;
-            });
+        final Note fullNote = new Note(null, note.getModified(), note.getTitle(), note.getContent(), note.getCategory(), note.getFavorite(), null);
+        deleteNoteAndSync(account, note.getId());
+        return map(addNoteAndSync(account, fullNote), (createdNote) -> {
+            db.getNoteDao().updateStatus(createdNote.getId(), DBStatus.LOCAL_EDITED);
+            createdNote.setStatus(DBStatus.LOCAL_EDITED);
+            return createdNote;
         });
     }
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/dao/NoteDao.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/dao/NoteDao.java
@@ -29,11 +29,7 @@ public interface NoteDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     int updateNote(Note newNote);
 
-    @Query("DELETE FROM NOTE WHERE accountId = :accountId")
-    int deleteByAccountId(Long accountId);
-
     String getNoteById = "SELECT * FROM NOTE WHERE id = :id";
-    String getContent = "SELECT content FROM NOTE WHERE id = :id";
     String count = "SELECT COUNT(*) FROM NOTE WHERE status != 'LOCAL_DELETED' AND accountId = :accountId";
     String countFavorites = "SELECT COUNT(*) FROM NOTE WHERE status != 'LOCAL_DELETED' AND accountId = :accountId AND favorite = 1";
     String searchRecentByModified = "SELECT id, remoteId, accountId, title, favorite, excerpt, modified, category, status, '' as eTag, '' as content, 0 as scrollY FROM NOTE WHERE accountId = :accountId AND status != 'LOCAL_DELETED' AND (title LIKE :query OR content LIKE :query) ORDER BY favorite DESC, modified DESC";
@@ -65,12 +61,6 @@ public interface NoteDao {
 
     @Query(countFavorites)
     Integer countFavorites(long accountId);
-
-    @Query(getContent)
-    LiveData<String> getContent$(Long id);
-
-    @Query(getContent)
-    String getContent(Long id);
 
     @Query(searchRecentByModified)
     LiveData<List<Note>> searchRecentByModified$(long accountId, String query);

--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesDaoTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesDaoTest.java
@@ -337,16 +337,6 @@ public class NotesDaoTest {
     }
 
     @Test
-    public void getContent() throws InterruptedException {
-        final Note note = new Note(1, 1L, Calendar.getInstance(), "My-Title", "My-Content", "", false, "1", LOCAL_DELETED, account.getId(), "", 0);
-        db.getNoteDao().addNote(note);
-        assertEquals("My-Content", db.getNoteDao().getContent(note.getId()));
-        assertEquals("My-Content", NotesTestingUtil.getOrAwaitValue(db.getNoteDao().getContent$(note.getId())));
-        assertNull(db.getNoteDao().getContent(note.getId() + 1));
-        assertNull(NotesTestingUtil.getOrAwaitValue(db.getNoteDao().getContent$(note.getId() + 1)));
-    }
-
-    @Test
     public void getCategoriesLiveData() throws InterruptedException {
         final Account secondAccount = setupSecondAccountAndTestNotes();
 

--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesRepositoryTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesRepositoryTest.java
@@ -226,6 +226,9 @@ public class NotesRepositoryTest {
         final Note movedNote = getOrAwaitValue(repoSpy.moveNoteToAnotherAccount(secondAccount, noteToMove));
 
         assertEquals(4, repoSpy.getLocalModifiedNotes(secondAccount.getId()).size());
+        assertEquals("美好的一天", movedNote.getTitle());
+        assertEquals("C", movedNote.getContent());
+        assertEquals("Movies", movedNote.getCategory());
         assertEquals(LOCAL_EDITED, movedNote.getStatus());
 
         verify(repoSpy, times(1)).deleteNoteAndSync(any(), anyLong());


### PR DESCRIPTION
- Moving from within a note using the 3-dots-menu did not work at all because no account was passed to the chooser
- Moving a note does no longer require to re-read the full content. This is already done by `MainViewModel`. The method expects the full note to be passed