### PR TITLE
Keep keyboard state when puting app to the background

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -144,15 +144,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         binding.editContent.addTextChangedListener(textWatcher);
 
         if(keyboardShown){
-            Toast.makeText(requireContext(),"OPEN",Toast.LENGTH_SHORT).show();
-        }
-    }
-
-    @Override
-    protected void onNoteLoaded(Note note) {
-        super.onNoteLoaded(note);
-        if (TextUtils.isEmpty(note.getContent())) {
-            binding.editContent.post(() -> {
+            binding.editContent.postDelayed(() -> {
                 binding.editContent.requestFocus();
 
                 final InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -161,7 +153,24 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
                 } else {
                     Log.e(TAG, InputMethodManager.class.getSimpleName() + " is null.");
                 }
-            });
+            },100);
+        }
+    }
+
+    @Override
+    protected void onNoteLoaded(Note note) {
+        super.onNoteLoaded(note);
+        if (TextUtils.isEmpty(note.getContent())) {
+            binding.editContent.postDelayed(() -> {
+               binding.editContent.requestFocus();
+
+                final InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (imm != null) {
+                    imm.showSoftInput(binding.editContent, InputMethodManager.SHOW_IMPLICIT);
+                } else {
+                    Log.e(TAG, InputMethodManager.class.getSimpleName() + " is null.");
+                }
+            },100);
         }
 
         binding.editContent.setMarkdownString(note.getContent());

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -141,7 +141,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         super.onResume();
         binding.editContent.addTextChangedListener(textWatcher);
 
-        if(keyboardShown){
+        if (keyboardShown) {
             openSoftKeyboard();
         }
     }
@@ -163,7 +163,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         }
     }
 
-    private void openSoftKeyboard(){
+    private void openSoftKeyboard() {
         binding.editContent.postDelayed(() -> {
             binding.editContent.requestFocus();
 
@@ -174,7 +174,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
                 Log.e(TAG, InputMethodManager.class.getSimpleName() + " is null.");
             }
             //Without a small delay the keyboard does not show reliably
-        },100);
+        }, 100);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -2,9 +2,7 @@ package it.niedermann.owncloud.notes.edit;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Rect;
 import android.graphics.Typeface;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -20,7 +18,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ScrollView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -2,7 +2,9 @@ package it.niedermann.owncloud.notes.edit;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Rect;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -18,6 +20,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ScrollView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -59,6 +62,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         }
     };
     private TextWatcher textWatcher;
+    private boolean keyboardShown = false;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -138,6 +142,10 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     public void onResume() {
         super.onResume();
         binding.editContent.addTextChangedListener(textWatcher);
+
+        if(keyboardShown){
+            Toast.makeText(requireContext(),"OPEN",Toast.LENGTH_SHORT).show();
+        }
     }
 
     @Override
@@ -171,6 +179,15 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         super.onPause();
         binding.editContent.removeTextChangedListener(textWatcher);
         cancelTimers();
+
+        final View parentView = ((ViewGroup) requireActivity().findViewById(android.R.id.content)).getChildAt(0);
+        final int defaultKeyboardHeightDP = 100;
+        final int EstimatedKeyboardDP = defaultKeyboardHeightDP + (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? 48 : 0);
+        final Rect rect = new Rect();
+        int estimatedKeyboardHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, EstimatedKeyboardDP, parentView.getResources().getDisplayMetrics());
+        parentView.getWindowVisibleDisplayFrame(rect);
+        int heightDiff = parentView.getRootView().getHeight() - (rect.bottom - rect.top);
+        keyboardShown = heightDiff >= estimatedKeyboardHeight;
     }
 
     private void cancelTimers() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -144,16 +144,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         binding.editContent.addTextChangedListener(textWatcher);
 
         if(keyboardShown){
-            binding.editContent.postDelayed(() -> {
-                binding.editContent.requestFocus();
-
-                final InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-                if (imm != null) {
-                    imm.showSoftInput(binding.editContent, InputMethodManager.SHOW_IMPLICIT);
-                } else {
-                    Log.e(TAG, InputMethodManager.class.getSimpleName() + " is null.");
-                }
-            },100);
+            openSoftKeyboard();
         }
     }
 
@@ -161,16 +152,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
     protected void onNoteLoaded(Note note) {
         super.onNoteLoaded(note);
         if (TextUtils.isEmpty(note.getContent())) {
-            binding.editContent.postDelayed(() -> {
-               binding.editContent.requestFocus();
-
-                final InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-                if (imm != null) {
-                    imm.showSoftInput(binding.editContent, InputMethodManager.SHOW_IMPLICIT);
-                } else {
-                    Log.e(TAG, InputMethodManager.class.getSimpleName() + " is null.");
-                }
-            },100);
+            openSoftKeyboard();
         }
 
         binding.editContent.setMarkdownString(note.getContent());
@@ -181,6 +163,20 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         if (sp.getBoolean(getString(R.string.pref_key_font), false)) {
             binding.editContent.setTypeface(Typeface.MONOSPACE);
         }
+    }
+
+    private void openSoftKeyboard(){
+        binding.editContent.postDelayed(() -> {
+            binding.editContent.requestFocus();
+
+            final InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (imm != null) {
+                imm.showSoftInput(binding.editContent, InputMethodManager.SHOW_IMPLICIT);
+            } else {
+                Log.e(TAG, InputMethodManager.class.getSimpleName() + " is null.");
+            }
+            //Without a small delay the keyboard does not show reliably
+        },100);
     }
 
     @Override

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -16,6 +16,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ScrollView;
 
@@ -183,8 +184,12 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         binding.editContent.removeTextChangedListener(textWatcher);
         cancelTimers();
 
-        final View parentView = ((ViewGroup) requireActivity().findViewById(android.R.id.content)).getChildAt(0);
-        keyboardShown = DisplayUtils.isSoftKeyboardVisible(parentView);
+        final ViewGroup parentView =  requireActivity().findViewById(android.R.id.content);
+        if(parentView != null && parentView.getChildCount() > 0){
+            keyboardShown = DisplayUtils.isSoftKeyboardVisible(parentView.getChildAt(0));
+        }else {
+            keyboardShown = false;
+        }
     }
 
     private void cancelTimers() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/NoteEditFragment.java
@@ -32,6 +32,7 @@ import it.niedermann.owncloud.notes.R;
 import it.niedermann.owncloud.notes.databinding.FragmentNoteEditBinding;
 import it.niedermann.owncloud.notes.persistence.entity.Note;
 import it.niedermann.owncloud.notes.shared.model.ISyncCallback;
+import it.niedermann.owncloud.notes.shared.util.DisplayUtils;
 
 import static androidx.core.view.ViewCompat.isAttachedToWindow;
 import static it.niedermann.owncloud.notes.shared.util.NoteUtil.getFontSizeFromPreferences;
@@ -186,13 +187,7 @@ public class NoteEditFragment extends SearchableBaseNoteFragment {
         cancelTimers();
 
         final View parentView = ((ViewGroup) requireActivity().findViewById(android.R.id.content)).getChildAt(0);
-        final int defaultKeyboardHeightDP = 100;
-        final int EstimatedKeyboardDP = defaultKeyboardHeightDP + (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? 48 : 0);
-        final Rect rect = new Rect();
-        int estimatedKeyboardHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, EstimatedKeyboardDP, parentView.getResources().getDisplayMetrics());
-        parentView.getWindowVisibleDisplayFrame(rect);
-        int heightDiff = parentView.getRootView().getHeight() - (rect.bottom - rect.top);
-        keyboardShown = heightDiff >= estimatedKeyboardHeight;
+        keyboardShown = DisplayUtils.isSoftKeyboardVisible(parentView);
     }
 
     private void cancelTimers() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/DisplayUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/DisplayUtils.java
@@ -58,11 +58,12 @@ public class DisplayUtils {
     }
 
     /**
-     *  Android does not provide a way to get keyboard visibility prior to API 30 so we use a workaround
+     * Android does not provide a way to get keyboard visibility prior to API 30 so we use a workaround
+     *
      * @param parentView View
      * @return keyboardVisibility Boolean
      */
-    public static boolean isSoftKeyboardVisible(View parentView){
+    public static boolean isSoftKeyboardVisible(View parentView) {
         //Arbitrary keyboard height
         final int defaultKeyboardHeightDP = 100;
         final int EstimatedKeyboardDP = defaultKeyboardHeightDP + (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? 48 : 0);

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/DisplayUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/DisplayUtils.java
@@ -11,11 +11,14 @@ import android.text.TextUtils;
 import android.text.style.MetricAffectingSpan;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.WindowInsets;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import java.util.Collection;
 import java.util.List;
@@ -58,12 +61,21 @@ public class DisplayUtils {
     }
 
     /**
-     * Android does not provide a way to get keyboard visibility prior to API 30 so we use a workaround
+     * Detect if the soft keyboard is open.
+     * On API prior to 30 we fall back to workaround which might be less reliable
      *
      * @param parentView View
      * @return keyboardVisibility Boolean
      */
-    public static boolean isSoftKeyboardVisible(View parentView) {
+    public static boolean isSoftKeyboardVisible(@NonNull View parentView) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(parentView);
+            if(insets != null){
+                return insets.isVisible(WindowInsets.Type.ime());
+            }
+        }
+        //Fall Back to workaround
+
         //Arbitrary keyboard height
         final int defaultKeyboardHeightDP = 100;
         final int EstimatedKeyboardDP = defaultKeyboardHeightDP + (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? 48 : 0);

--- a/app/src/main/java/it/niedermann/owncloud/notes/shared/util/DisplayUtils.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/shared/util/DisplayUtils.java
@@ -3,10 +3,14 @@ package it.niedermann.owncloud.notes.shared.util;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Color;
+import android.graphics.Rect;
+import android.os.Build;
 import android.text.Spannable;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.style.MetricAffectingSpan;
+import android.util.TypedValue;
+import android.view.View;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -51,5 +55,22 @@ public class DisplayUtils {
             icon = R.drawable.ic_work_grey600_24dp;
         }
         return new NavigationItem.CategoryNavigationItem("category:" + counter.getCategory(), counter.getCategory(), counter.getTotalNotes(), icon, counter.getAccountId(), counter.getCategory());
+    }
+
+    /**
+     *  Android does not provide a way to get keyboard visibility prior to API 30 so we use a workaround
+     * @param parentView View
+     * @return keyboardVisibility Boolean
+     */
+    public static boolean isSoftKeyboardVisible(View parentView){
+        //Arbitrary keyboard height
+        final int defaultKeyboardHeightDP = 100;
+        final int EstimatedKeyboardDP = defaultKeyboardHeightDP + (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? 48 : 0);
+        final Rect rect = new Rect();
+
+        int estimatedKeyboardHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, EstimatedKeyboardDP, parentView.getResources().getDisplayMetrics());
+        parentView.getWindowVisibleDisplayFrame(rect);
+        int heightDiff = parentView.getRootView().getHeight() - (rect.bottom - rect.top);
+        return heightDiff >= estimatedKeyboardHeight;
     }
 }


### PR DESCRIPTION
Solves #993

Had to use some workaround to get the state of the keyboard. 
After some manual testing it seems to work well enough and other big app are also relying on this (ex:Firefox mobile). Android does not seem to provide the required functions for this prior to API 30.

Anyway let me know if there is any issue with this PR I'll gladly fix it (if possible)