### PR TITLE
#1281 Prevent duplicate key exception

### DIFF
--- a/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesRepositoryTest.java
+++ b/app/src/test/java/it/niedermann/owncloud/notes/persistence/NotesRepositoryTest.java
@@ -71,9 +71,10 @@ public class NotesRepositoryTest {
                 .allowMainThreadQueries()
                 .build();
 
-        final Constructor<NotesRepository> constructor = NotesRepository.class.getDeclaredConstructor(Context.class, NotesDatabase.class, ExecutorService.class, ApiProvider.class);
+        final Constructor<NotesRepository> constructor = NotesRepository.class.getDeclaredConstructor(Context.class, NotesDatabase.class, ExecutorService.class, ExecutorService.class, ApiProvider.class);
         constructor.setAccessible(true);
-        repo = constructor.newInstance(context, db, MoreExecutors.newDirectExecutorService(), ApiProvider.getInstance());
+        final ExecutorService executor = MoreExecutors.newDirectExecutorService();
+        repo = constructor.newInstance(context, db, executor, executor, ApiProvider.getInstance());
 
         repo.addAccount("https://äöüß.example.com", "彼得", "彼得@äöüß.example.com", new Capabilities(), null, new IResponseCallback<Account>() {
             @Override


### PR DESCRIPTION
Fix #1281 Use SingleThreadExecutor for performing remote synchronization tasks

Signed-off-by: Stefan Niedermann <info@niedermann.it>