### PR TITLE
#522 Overflow-menu contains "search" when searchview is open

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/edit/SearchableBaseNoteFragment.java
@@ -72,10 +72,9 @@ public abstract class SearchableBaseNoteFragment extends BaseNoteFragment {
             searchMenuItem.expandActionView();
             searchView.setQuery(searchQuery, true);
             searchView.clearFocus();
-        } else {
-            searchMenuItem.collapseActionView();
         }
 
+        searchMenuItem.collapseActionView();
 
         final var searchEditFrame = searchView.findViewById(R.id
                 .search_edit_frame);


### PR DESCRIPTION
Hey, I removed the condition to collapse the search menu. It should now works as intended, when opening the menu, it now collapse the search menu in both Edit and Preview mode end there is no "search" item in the menu list. I don't know if that breaks anything though.

Original behaviour :
![before](https://user-images.githubusercontent.com/89147152/135762125-cf9ebf4f-ea3a-4f8f-9b50-e5b0a1416c4a.gif)

New behaviour:
![after](https://user-images.githubusercontent.com/89147152/135762133-97884cd5-1a74-4487-a5d7-390ebb39af03.gif)

Fix #522 