### PR TITLE
Add monochrome icon

### DIFF
--- a/app/src/dev/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/dev/res/drawable/ic_launcher_foreground.xml
@@ -12,19 +12,18 @@
             android:pathData="m24.484 3.5156c-1.0237 0-2.0471 0.38887-2.8281 1.1699l5.6582 5.6582c1.5621-1.5621 1.5621-4.0961 0-5.6582-0.78105-0.78105-1.8064-1.1699-2.8301-1.1699zm-4.2422 2.584-12.02 12.021 5.6562 5.6562 12.021-12.02-5.6582-5.6582zm-13.436 13.436-2.1211 7.7793 7.7793-2.1211-5.6582-5.6582z" />
     </group>
     <group
-        android:translateX="27.6"
-        android:translateY="34.7"
-        android:rotation="-45"
-        android:scaleX=".13"
-        android:scaleY=".13">
+        android:scaleX=".20"
+        android:scaleY=".23"
+        android:translateX="33"
+        android:translateY="38">
         <path
-            android:pathData="M11.908125 40h11.4c4.44 0 7.24 -1.04 9.2 -3.4 2.32 -2.72 3.56 -6.68 3.56 -11.2 0 -4.48 -1.24 -8.44 -3.56 -11.2 -1.96 -2.36 -4.72 -3.36 -9.2 -3.36h-11.4zm6 -5V15.84h5.4c4.52 0 6.76 3.16 6.76 9.6 0 6.4 -2.24 9.56 -6.76 9.56z"
-            android:fillColor="#0991db"/>
+            android:fillColor="#ffffff"
+            android:pathData="M11.908125 40h11.4c4.44 0 7.24 -1.04 9.2 -3.4 2.32 -2.72 3.56 -6.68 3.56 -11.2 0 -4.48 -1.24 -8.44 -3.56 -11.2 -1.96 -2.36 -4.72 -3.36 -9.2 -3.36h-11.4zm6 -5V15.84h5.4c4.52 0 6.76 3.16 6.76 9.6 0 6.4 -2.24 9.56 -6.76 9.56z" />
         <path
-            android:pathData="M46.894375 27.44h13.96v-5h-13.96v-6.6h15.08v-5h-21.08V40h21.8v-5h-15.8z"
-            android:fillColor="#0d96e1"/>
+            android:fillColor="#ffffff"
+            android:pathData="M46.894375 27.44h13.96v-5h-13.96v-6.6h15.08v-5h-21.08V40h21.8v-5h-15.8z" />
         <path
-            android:pathData="M80.333125 40l10 -29.16h-6.04l-6.36 21.96 -6.48 -21.96h-6.04l9.84 29.16z"
-            android:fillColor="#0f9ae6"/>
+            android:fillColor="#ffffff"
+            android:pathData="M80.333125 40l10 -29.16h-6.04l-6.36 21.96 -6.48 -21.96h-6.04l9.84 29.16z" />
     </group>
 </vector>

--- a/app/src/dev/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/dev/res/drawable/ic_launcher_foreground.xml
@@ -4,7 +4,8 @@
     android:height="108dp"
     android:viewportWidth="66.666664"
     android:viewportHeight="66.666664">
-    <group android:translateX="17.333334"
+    <group
+        android:translateX="17.333334"
         android:translateY="17.333334">
         <path
             android:fillColor="#fff"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Uses the existing icon to provide a monochrome variant of the icon, to support Android 12+ themed icons. Closes #1543.

![image](https://user-images.githubusercontent.com/12085737/177411521-8ae95b42-7ae3-412b-bced-9a753e4fac3b.png)

On a side note, I've been considering whether or not we should keep the "DEV" text in the monochrome variant. A way around this would be having a single SVG path, rather than several overlaying each other. That way, the DEV text would be preserved. I however haven't found an easy way to do that, and I'm not that skilled in SVGs.

It does still show in places where the themed icon isn't applied :

![image](https://user-images.githubusercontent.com/12085737/177411538-bfd0c638-8e0c-45df-a869-9d20d609e92b.png)
